### PR TITLE
[CI/CD] dev-deploy.yml 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -64,8 +64,8 @@ jobs:
           key: ${{ secrets.KEY }}
           port: 22
           script: |
-            sudo docker stop prod-server
-            sudo docker rm prod-server
+            sudo docker stop spring-dev
+            sudo docker rm spring-dev
             sudo docker image rm ${{ secrets.DOCKER_REPO }}
             sudo docker pull ${{ secrets.DOCKER_REPO }}:latest-dev
             sudo docker run -d --name spring-dev -p 8080:8080 ${{ secrets.DOCKER_REPO }}:latest-dev

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,6 +1,17 @@
 version: 0.0
 os: ubuntu
 
+files:
+  - source:  /
+    destination: /home/ubuntu/app
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+
 hooks:
   ApplicationStart:
     - location: run.sh


### PR DESCRIPTION
## 관련 이슈 번호
- #8

## 작업사항
github actions 에러 log
```
err: docker: Error response from daemon: Conflict. The container name "/spring-dev" is already in use by container "bc3e11fb0441dc1d3a0e0efb06a2b1a4c4d2e2760363253a1f9bbff99b8959e1". You have to remove (or rename) that container to be able to reuse that name.
```
- 이전에 실행하던 컨테이너 중지 및 삭제를 하지 않아서 포트 중복 발생 에러 해결

## 변경로직
- dev-deploy.yml에 잘못 적혀있던 컨테이너 이름 수정