### PR TITLE
[Feature] BaseTimeEntity 생성

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -64,8 +64,8 @@ jobs:
           key: ${{ secrets.KEY }}
           port: 22
           script: |
-            sudo docker stop prod-server
-            sudo docker rm prod-server
+            sudo docker stop spring-dev
+            sudo docker rm spring-dev
             sudo docker image rm ${{ secrets.DOCKER_REPO }}
             sudo docker pull ${{ secrets.DOCKER_REPO }}:latest-dev
             sudo docker run -d --name spring-dev -p 8080:8080 ${{ secrets.DOCKER_REPO }}:latest-dev

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,6 +1,17 @@
 version: 0.0
 os: ubuntu
 
+files:
+  - source:  /
+    destination: /home/ubuntu/app
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+
 hooks:
   ApplicationStart:
     - location: run.sh

--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -2,7 +2,9 @@ package com.soma.snackexercise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SnackExerciseApplication {
 

--- a/src/main/java/com/soma/snackexercise/domain/BaseTimeEntity.java
+++ b/src/main/java/com/soma/snackexercise/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.soma.snackexercise.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 관련 이슈 번호
- close #23 

## 작업사항
- 모든 Entity의 공통 컬럼인 생성시간, 수정시간 컬럼을 위한 BaseTimeEntity를 생성
- JPA Auditing 어노테이션들을 모두 활성화할 수 있도록 Application 클래스에 @EnableJpaAuditing을 추가
