### PR TITLE
[Feature] AWS Health Check 성공을 위한 컨트롤러 추가

### DIFF
--- a/src/main/java/com/soma/snackexercise/controller/HealthController.java
+++ b/src/main/java/com/soma/snackexercise/controller/HealthController.java
@@ -1,0 +1,10 @@
+package com.soma.snackexercise.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class HealthController {
+    @GetMapping("/health")
+    public String healthCheck(){
+        return "health";
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- #8

## 작업사항
- AWS Health Check 성공을 위해서 `/health` uri에 대해서 `health` string을 반환하는 컨트롤러 추가