### PR TITLE
[Feature] AWS Health Check 성공을 위한 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/soma/snackexercise/controller/HealthController.java
+++ b/src/main/java/com/soma/snackexercise/controller/HealthController.java
@@ -1,7 +1,9 @@
 package com.soma.snackexercise.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
 public class HealthController {
     @GetMapping("/health")
     public String healthCheck(){


### PR DESCRIPTION
## 관련 이슈 번호
- #8

## 작업사항
- AWS Health Check 성공을 위해서 `/health`에 대해서 `health` 문자열이 반환되도록 수정

## 변경로직
- HealthController에 @RestController 어노테이션 추가
- build.gradle security관련 의존성 주석 처리
