### PR TITLE
[Fix] swagger cors 에러 해결

### DIFF
--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -1,9 +1,12 @@
 package com.soma.snackexercise;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev.snackexercise.com")})
 @EnableJpaAuditing
 @SpringBootApplication
 public class SnackExerciseApplication {


### PR DESCRIPTION
## 작업사항
- 응답을 보내주는 AWS 서버는 https, 응답을 요청하는 swagger 서버는 http를 사용해서 CORS 에러 해결


## 변경로직
- Application에 swagger의 url을 변경하는 코드 작성

