### PR TITLE
[Fix]: Enum이 String 데이터 형식으로 저장되도록 수정

### DIFF
--- a/src/main/java/com/soma/snackexercise/domain/exercise/Exercise.java
+++ b/src/main/java/com/soma/snackexercise/domain/exercise/Exercise.java
@@ -1,10 +1,7 @@
 package com.soma.snackexercise.domain.exercise;
 
 import com.soma.snackexercise.domain.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -18,6 +15,7 @@ public class Exercise extends BaseEntity {
 
     private String name;
 
+    @Enumerated(EnumType.STRING)
     private ExerciseCategory exerciseCategory;
 
     private String videoLink;


### PR DESCRIPTION
## 관련 이슈 번호
- close #50

## 작업사항
- Enum값이 DB에 저장될 때 String 형식으로 저장되도록 수정하였습니다.
