### PR TITLE
[Feature]  당일 릴레이미션 수행 현황 정보 조회 기능

### DIFF
--- a/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
+++ b/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
@@ -1,0 +1,26 @@
+package com.soma.snackexercise.controller.mission;
+
+import com.soma.snackexercise.service.mission.MissionService;
+import com.soma.snackexercise.util.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mission", description = "미션 API")
+@RequiredArgsConstructor
+@RestController()
+public class MissionController {
+    private final MissionService missionService;
+
+    @Operation(summary = "당일 미션 수행 현황 조회", description = "당일 미션 수행 현황을 조회합니다.", security = { @SecurityRequirement(name = "bearer-key") })
+    @Parameter(name = "exgroupId", description = "조회할 운동 그룹 ID")
+    @GetMapping("/exgroups/{exgroupId}/missions")
+    public Response getTodayMissionResults(@PathVariable("exgroupId") Long exgroupId){
+        return Response.success(missionService.getTodayMissionResults(exgroupId));
+    }
+}

--- a/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
+++ b/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
@@ -1,0 +1,60 @@
+package com.soma.snackexercise.domain.mission;
+
+
+import com.soma.snackexercise.domain.BaseEntity;
+import com.soma.snackexercise.domain.exercise.Exercise;
+import com.soma.snackexercise.domain.exgroup.Exgroup;
+import com.soma.snackexercise.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Mission extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "exerciseId")
+    private Exercise exercise;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "exgroupId")
+    private Exgroup exgroup;
+
+    private Integer calory; // 소모 칼로리
+
+    private LocalDateTime startAt; // 운동 시작 일시
+
+    private LocalDateTime endAt; // 운동 종료 일시
+
+    private Integer alarmCount; // 독촉 알람 횟수
+
+
+    @Builder
+    public Mission(Exercise exercise, Member member, Exgroup exgroup, Integer alarmCount) {
+        this.exercise = exercise;
+        this.member = member;
+        this.exgroup = exgroup;
+        this.alarmCount = 0;
+        active();
+    }
+
+    public void startMission(){
+        this.startAt = LocalDateTime.now();
+    }
+
+    public void endMission(Integer calory){
+        this.endAt = LocalDateTime.now();
+        this.calory = calory;
+    }
+}

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
@@ -1,0 +1,16 @@
+package com.soma.snackexercise.dto.mission.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MemberMissionDto {
+    private Long memberId;
+    private String memberName;
+    private String profileImage;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+}

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/TodayMissionCurrentResultDto.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/TodayMissionCurrentResultDto.java
@@ -1,0 +1,15 @@
+package com.soma.snackexercise.dto.mission.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class TodayMissionCurrentResultDto {
+    private List<MemberMissionDto> missionFlow;
+    private Integer finishedRelayCount; // 현재까지 완료한 릴레이 횟수
+    private LocalDate exgroupEndDate; // 그룹 종료 일자
+}

--- a/src/main/java/com/soma/snackexercise/repository/mission/MisssionRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/mission/MisssionRepository.java
@@ -1,0 +1,25 @@
+package com.soma.snackexercise.repository.mission;
+
+import com.soma.snackexercise.domain.mission.Mission;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MisssionRepository extends JpaRepository<Mission, Long> {
+    @Query("SELECT count(*) AS cnt" +
+            "    FROM Mission m" +
+            "    WHERE m.exgroup.id = :exgroupId AND :today <= m.createdAt AND m.createdAt < :nextday AND m.endAt IS NOT NULL" +
+            "    GROUP BY m.member" +
+            "    ORDER BY cnt DESC" +
+            "    LIMIT 1")
+    Integer findCurrentFinishedRelayCountByGroupId(@Param("exgroupId") Long exgroupId, @Param("today") LocalDateTime today, @Param("nextday") LocalDateTime nextday);
+
+    @Query("SELECT m" +
+            "   FROM Mission m" +
+            "   WHERE m.exgroup.id = :exgroupId AND :today <= m.createdAt AND m.createdAt < :nextday" +
+            "   ORDER BY m.createdAt")
+    List<Mission> findAllMissionByGroupIdAndCreatedAt(@Param("exgroupId") Long exgroupId, @Param("today") LocalDateTime today, @Param("nextday") LocalDateTime nextday);
+}

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -1,0 +1,42 @@
+package com.soma.snackexercise.service.mission;
+
+import com.soma.snackexercise.domain.exgroup.Exgroup;
+import com.soma.snackexercise.domain.mission.Mission;
+import com.soma.snackexercise.dto.mission.response.MemberMissionDto;
+import com.soma.snackexercise.dto.mission.response.TodayMissionCurrentResultDto;
+import com.soma.snackexercise.exception.ExgroupNotFoundException;
+import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
+import com.soma.snackexercise.repository.mission.MisssionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class MissionService {
+
+    private final MisssionRepository misssionRepository;
+    private final ExgroupRepository exgroupRepository;
+
+
+    public TodayMissionCurrentResultDto getTodayMissionResults(Long exgroupId) {
+        // 1. 그룹의 종료일자
+        Exgroup exgroup = exgroupRepository.findById(exgroupId).orElseThrow(ExgroupNotFoundException::new);
+
+        // 2. 그룹이 현재 완료한 릴레이 횟수
+        LocalDateTime now = LocalDateTime.now();// 현재 날짜와 시간 가져오기
+        LocalDateTime todayMidnight = now.with(LocalTime.MIN);// 오늘 자정 구하기
+        LocalDateTime tomorrowMidnight = now.plusDays(1).with(LocalTime.MIN);// 내일 자정 구하기
+
+        Integer currentFinishedRelayCount = misssionRepository.findCurrentFinishedRelayCountByGroupId(exgroupId, todayMidnight, tomorrowMidnight);
+
+        // 3. 모든 그룹원의 오늘 수행한 미션 현황
+        List<Mission> missions = misssionRepository.findAllMissionByGroupIdAndCreatedAt(exgroupId, todayMidnight, tomorrowMidnight);
+        List<MemberMissionDto> missionFlow = missions.stream().map(mission -> new MemberMissionDto(mission.getMember().getId(), mission.getMember().getNickname(), mission.getMember().getProfileImage(), mission.getCreatedAt(), mission.getEndAt())).toList();
+
+        return new TodayMissionCurrentResultDto(missionFlow, currentFinishedRelayCount, exgroup.getEndDate());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,9 +8,9 @@ spring:
     properties:
       hibernate.format_sql: true
     hibernate:
-      hbm2ddl.auto: update
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+      ddl-auto: create
     defer-datasource-initialization: true
 
   h2:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -23,3 +23,25 @@ INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, o
 INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (6, 5, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0);
 INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (7, 6, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0);
 INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (8, 7, 2, '2023-07-21 15:06:18', 'MEMBER', '2023-07-21 15:06:18', 0);
+
+-- INSERT EXERCISE
+INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, '2023-07-23 11:16:04.000000', 1, '2023-07-23 11:16:03.000000', '어디서나 할 수 있는 전신 운동 입니다
+', 'EXERCISE', '전신 운동', 'ACTIVE', 'https://www.youtube.com/shorts/GA2DFir8fbo');
+INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (15, '2023-07-23 14:44:15.000000', 2, '2023-07-23 14:44:22.000000', '서서하는 복근 운동
+', 'EXERCISE', '서서하는 복근 운동
+', 'ACTIVE', 'https://www.youtube.com/shorts/m-kAmwkanoI');
+INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (20, '2023-07-23 14:44:17.000000', 3, '2023-07-23 14:44:20.000000', '하체 운동
+', 'EXERCISE', '하체 운동
+', 'ACTIVE', 'https://www.youtube.com/shorts/l1CEorIKDcE');
+INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, '2023-07-23 14:44:18.000000', 4, '2023-07-23 14:44:23.000000', '구석구석 유산소
+', 'EXERCISE', '구석구석 유산소', 'ACTIVE', 'https://www.youtube.com/shorts/yDwnyQeLB8c');
+INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, '2023-07-23 14:44:19.000000', 5, '2023-07-23 14:44:24.000000', '복근 운동', 'EXERCISE', '복근 운동', 'ACTIVE', 'https://www.youtube.com/shorts/1K0Ono8vo1o');
+
+-- INSERT MISSION
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (0, 10, '2023-07-23 16:30:44.000000', '2023-07-23 16:40:42.000000', 1, 2, 1, 1, '2023-07-23 16:35:35.000000', '2023-07-23 16:30:44.000000', 'ACTIVE');
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (0, 15, '2023-07-23 16:40:42.000000', '2023-07-23 16:57:35.000000', 3, 2, 2, 3, '2023-07-23 16:50:42.000000', '2023-07-23 16:40:42.000000', 'ACTIVE');
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (2, 25, '2023-07-23 16:57:35.000000', '2023-07-23 18:08:29.000000', 4, 2, 3, 5, '2023-07-23 18:00:35.000000', '2023-07-23 16:57:35.000000', 'ACTIVE');
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (0, 20, '2023-07-23 18:08:29.000000', '2023-07-23 18:20:29.000000', 5, 2, 4, 6, '2023-07-23 18:11:29.000000', '2023-07-23 18:08:29.000000', 'ACTIVE');
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (0, null, '2023-07-23 18:20:29.000000', null, 3, 2, 5, 2, null, '2023-07-23 18:20:29.000000', 'ACTIVE');
+INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, exgroupId, id, memberId, startAt, updatedAt, status) VALUES (0, null, '2023-07-23 09:00:48.000000', null, 2, 3, 6, 1, null, '2023-07-23 09:00:48.000000', 'ACTIVE');
+


### PR DESCRIPTION
## 관련 이슈 번호
- close #63

## 작업사항
- 당일 릴레이미션 수행 현황 정보 조회 기능을 구현하였습니다.
- 릴레이미션을 할당 받은 시각, 끝낸 시각을 비롯해 해당 미션을 수행한 회원의 정보를 조회할 수 있습니다.
