### PR TITLE
[Refactor] Jwt 인증 인가 로직 리팩토링

### DIFF
--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -6,6 +6,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    /* Authorization */
+    TOKEN_EXPIRED_EXCEPTION(-1000, "토큰이 만료되었습니다."),
+
+    /* Member */
+    MEMBER_NAME_ALREADY_EXISTS_EXCEPTION(-1100, "유저 이름이 이미 존재합니다."),
+
     /* Exgroup */
     NOT_FOUND_EXGROUP(1200, "운동 그룹이 존재하지 않습니다.");
     

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -1,15 +1,38 @@
 package com.soma.snackexercise.advice;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.soma.snackexercise.exception.ExgroupNotFoundException;
+import com.soma.snackexercise.exception.MemberNameAlreadyExistsException;
 import com.soma.snackexercise.util.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import static com.soma.snackexercise.advice.ErrorCode.NOT_FOUND_EXGROUP;
+
+import static com.soma.snackexercise.advice.ErrorCode.*;
 
 @RestControllerAdvice
 @Slf4j
 public class ExceptionAdvice {
+    /*
+    Authorization
+     */
+    @ExceptionHandler(TokenExpiredException.class)
+    public Response tokenExpiredException(TokenExpiredException e) {
+        return Response.failure(TOKEN_EXPIRED_EXCEPTION);
+    }
+
+
+    /*
+    Member
+     */
+    @ExceptionHandler(MemberNameAlreadyExistsException.class)
+    public Response memberNameAlreadyExistsException(MemberNameAlreadyExistsException e) {
+        return Response.failure(MEMBER_NAME_ALREADY_EXISTS_EXCEPTION);
+    }
+
+    /*
+    Exgroup
+     */
     @ExceptionHandler(ExgroupNotFoundException.class)
     public Response exgroupNotFoundExceptionHandler(ExgroupNotFoundException e){
         return Response.failure(NOT_FOUND_EXGROUP);

--- a/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -59,7 +59,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
          */
         String refreshToken = jwtService.extractRefreshToken(request)
                 .filter(jwtService::isTokenValid)
-                .filter(jwtService::isRefreshTokenMatch)
                 .orElse(null);
 
         /*

--- a/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,8 +1,6 @@
 package com.soma.snackexercise.auth.jwt.filter;
 
 import com.soma.snackexercise.auth.jwt.service.JwtService;
-import com.soma.snackexercise.auth.jwt.util.PasswordUtil;
-import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.repository.member.MemberRepository;
 import com.soma.snackexercise.util.RedisUtil;
 import jakarta.servlet.FilterChain;
@@ -11,111 +9,39 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /*
 Jwt 인증 필터 ("/login" 이외의 URI 요청이 왔을 때 처리하는 필터)
-
-기본적으로 사용자는 요청 헤더에 AccessToken만 담아서 요청
-AccessToken 만료 시에만 RefreshToken을 요청 헤더에 AccessToken과 함께 요청
-
-1. RefreshToken이 없고, AccessToken이 유효 -> 인증 성공, RefreshToken을 재발급하지는 않는다.
-2. RefreshToken이 없고, AccessToken이 없거나 유효하지 않은 경우 -> 인증 실패 처리, 403 Error
-3. RefreshToken이 있는 경우 -> DB의 RefreshToken과 비교하여 일치하면 AccessToken 재발급, RefreshToken 재발급 (RTR)
-                            인증 성공 처리는 하지 않고 실패 처리
  */
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
-    private static final String NO_CHECK_URL = "/login";
+    private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList("/login", "/api/auth/reissue", "/api/auth/logout"));
 
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
     private final RedisUtil redisUtil;
 
-    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("JwtAuthenticationProcessingFilter 호출");
-        if (request.getRequestURI().equals(NO_CHECK_URL)) {
+        if (NO_CHECK_URLS.stream().anyMatch(url -> url.equals(request.getRequestURI()))) {
             filterChain.doFilter(request, response);
             return;
         }
+        log.info("JwtAuthenticationProcessingFilter 호출");
+        String accessToken = jwtService.extractAccessToken(request).orElse(null);
 
-        /*
-        RefreshToken이 없거나 유효하지 않다면 null 반환
-        RefreshToken이 있는 경우, AccessToken이 만료되어 요청한 경우 밖에 없다.
-         */
-        String refreshToken = jwtService.extractRefreshToken(request)
-                .filter(jwtService::isTokenValid)
-                .orElse(null);
-
-        /*
-        RefreshToken이 존재했다면, RefreshToken이 DB의 RefreshToken과 일치한지 판단 후, 일치하면 AccessToken을 재발급
-         */
-        if (refreshToken != null) {
-            log.info("refreshToken이 있네요");
-            checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-            return;
+        if (jwtService.isTokenValid(accessToken)) {
+            jwtService.extractEmail(accessToken)
+                    .ifPresent(email -> memberRepository.findByEmail(email)
+                            .ifPresent(jwtService::saveAuthentication));
         }
-
-        if (refreshToken == null) {
-            log.info("refreshToken이 없네요");
-            checkAccessTokenAndAuthentication(request, response, filterChain);
-        }
-    }
-
-    /*
-    [리프레시 토큰의 이메일로 유저 정보 찾기 & 액세스 토큰/리프레시 토큰 재발급 메소드]
-    파라미터로 들어온 헤더에서 추출한 리프레시 토큰의 이메일로 DB에서 리프레시 토큰을 찾고,
-     */
-    public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
-        log.info("checkRefreshTokenAndReIssueAccessToken() 호출");
-        String email = jwtService.extractEmail(refreshToken).orElse(null);
-        Member findMember = memberRepository.findByEmail(email).orElse(null);
-
-        if (email != null && findMember != null) {
-            String reIssuedRefreshToken = reIssueRefreshToken(email);
-            jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(email), reIssuedRefreshToken);
-        }
-    }
-
-    /*
-    RefreshToken 재발급 후, Redis에 업데이트
-     */
-    private String reIssueRefreshToken(String email) {
-        String reIssuedRefreshToken = jwtService.createRefreshToken(email);
-        redisUtil.set(email, reIssuedRefreshToken, jwtService.getRefreshTokenExpirationPeriod());
-        return reIssuedRefreshToken;
-    }
-
-    /*
-    [엑세스 토큰 체크 & 인증 처리 메소드]
-    request에서 accessToken 추출 후, 유효한 토큰인지 확인
-    AccessToken의 이메일로 유저 객체를 saveAuthentication()으로 인증 처리
-    그후 객체를 SecurityContextHolder에 담기
-     */
-    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
-                                                  FilterChain filterChain) throws ServletException, IOException {
-        log.info("checkAccessTokenAndAuthentication() 호출");
-        jwtService.extractAccessToken(request)
-                .filter(jwtService::isTokenValid)
-                .ifPresent(accessToken -> jwtService.extractEmail(accessToken)
-                        .ifPresent(email -> memberRepository.findByEmail(email)
-                                .ifPresent(jwtService::saveAuthentication)));
-
         filterChain.doFilter(request, response);
     }
-
 }

--- a/src/main/java/com/soma/snackexercise/auth/jwt/service/JwtService.java
+++ b/src/main/java/com/soma/snackexercise/auth/jwt/service/JwtService.java
@@ -3,22 +3,22 @@ package com.soma.snackexercise.auth.jwt.service;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soma.snackexercise.auth.jwt.util.PasswordUtil;
 import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.dto.auth.AccessTokenResponse;
 import com.soma.snackexercise.exception.ExpiredJwtException;
 import com.soma.snackexercise.exception.InvalidRefreshTokenException;
 import com.soma.snackexercise.exception.UnauthorizedException;
 import com.soma.snackexercise.repository.member.MemberRepository;
 import com.soma.snackexercise.util.RedisUtil;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
@@ -26,9 +26,9 @@ import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.oauth2.jwt.JwtDecoderInitializationException;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.Optional;
 
@@ -42,10 +42,10 @@ public class JwtService {
     private String secretKey;
 
     @Value("${jwt.access.expiration}")
-    private Long accessTokenExpirationPeriod;
+    private Integer accessTokenExpirationPeriod;
 
     @Value("${jwt.refresh.expiration}")
-    private Long refreshTokenExpirationPeriod;
+    private Integer refreshTokenExpirationPeriod;
 
     @Value("${jwt.access.header}")
     private String accessHeader;
@@ -66,8 +66,6 @@ public class JwtService {
     public String createAccessToken(String email) {
         Date now = new Date();
 
-        System.out.println(new Date(now.getTime() + accessTokenExpirationPeriod) + "--------------------------");
-
         return JWT.create()
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
@@ -84,29 +82,27 @@ public class JwtService {
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
-    public void sendAccessToken(HttpServletResponse response, String accessToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
-
-        response.setHeader(accessHeader, accessToken);
-        log.info("재발급된 Access Token : {}", accessToken);
-    }
-
-    public void sendRefreshToken(HttpServletResponse response, String refreshToken) {
-
-    }
-
-    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
-        response.setStatus(HttpServletResponse.SC_OK);
+    public void sendAccessToken(HttpServletResponse response, String accessToken) throws IOException {
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
 
-        //JWT DTO 만들기
-
-        response.setHeader(accessHeader, accessToken);
-        response.setHeader(refreshHeader, refreshToken);
-        log.info("Access Token, Refresh Token 헤더 설정 완료");
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse(accessToken);
+        String result = objectMapper.writeValueAsString(accessTokenResponse);
+        response.getWriter().write(result);
+        response.setHeader(ACCESS_TOKEN_SUBJECT, accessToken);
+        log.info("sendAccessToken 실행");
     }
 
+    public void sendRefreshToken(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_SUBJECT, refreshToken);
+        cookie.setMaxAge(refreshTokenExpirationPeriod);
+
+        cookie.setSecure(true); // HTTPS에서만 전송
+        cookie.setHttpOnly(true); // XSS 방지
+        cookie.setPath("/"); // 도메인 내의 모든 경로에 전송
+
+        response.addCookie(cookie);
+    }
     /*
     헤더에서 AccessToken 추출
      */
@@ -119,10 +115,18 @@ public class JwtService {
     /*
     헤더에서 RefreshToken 추출
      */
-    public Optional<String> extractRefreshToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(refreshHeader))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    public String extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(REFRESH_TOKEN_SUBJECT)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
     }
 
     /*
@@ -140,20 +144,6 @@ public class JwtService {
             log.error("토큰이 유효하지 않습니다.");
             return Optional.empty();
         }
-    }
-
-    /*
-    AccessToken 헤더 설정
-     */
-    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
-        response.setHeader(accessHeader, accessToken);
-    }
-
-    /*
-    RefreshToken 헤더 설정
-     */
-    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
-        response.setHeader(refreshHeader, refreshToken);
     }
 
     /*
@@ -187,6 +177,8 @@ public class JwtService {
         } catch (UnauthorizedException e) {
             log.info("이미 탈퇴한 회원입니다.");
         } catch (Exception e) {
+            log.error(e.getMessage());
+            e.printStackTrace();
             log.info("잘못된 JWT 토큰입니다.");
         }
         return false;
@@ -195,20 +187,12 @@ public class JwtService {
     /*
     RefreshToken이 DB에 저장된 RefreshToken과 일치한지 확인
      */
-    public boolean isRefreshTokenMatch(String refreshToken) {
-        String email = extractEmail(refreshToken).orElseThrow(InvalidRefreshTokenException::new);
+    public boolean isRefreshTokenMatch(String email, String refreshToken) {
         if (redisUtil.get(email).equals(refreshToken)) {
             return true;
         }
 
         throw new InvalidRefreshTokenException();
-    }
-
-    public void sendAccessAndRefreshByEmail(HttpServletResponse response, String email) {
-        String AT = createAccessToken(email);
-        String RT = createRefreshToken(email);
-        updateRefreshToken(email, RT);
-        sendAccessAndRefreshToken(response, AT, RT);
     }
 
     public void saveAuthentication(Member myMember) {

--- a/src/main/java/com/soma/snackexercise/auth/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/soma/snackexercise/auth/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -32,12 +32,10 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
             if (oAuth2User.getRole() == Role.GUEST) {
                 String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
-                response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+                jwtService.sendAccessToken(response, accessToken);
                 response.sendRedirect("jwt-test");
 
-                jwtService.sendAccessAndRefreshToken(response, accessToken, null);
-
-                log.info("OAuth2 Login 성공 -> sendAccessAndRefreshToken 호출");
+                log.info("OAuth2 Login 성공");
             }else{
                 loginSuccess(response, oAuth2User);
             }
@@ -49,10 +47,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
         String accessToken = jwtService.createAccessToken(oAuth2User.getEmail());
         String refreshToken = jwtService.createRefreshToken(oAuth2User.getEmail());
-        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
-        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
 
-        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtService.sendAccessToken(response, accessToken);
+        jwtService.sendRefreshToken(response, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
     }
 }

--- a/src/main/java/com/soma/snackexercise/controller/auth/AuthController.java
+++ b/src/main/java/com/soma/snackexercise/controller/auth/AuthController.java
@@ -11,18 +11,18 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RestController("/api/auth")
+@RestController
 public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/reissue")
+    @PostMapping("/api/auth/reissue")
+    @ResponseStatus(HttpStatus.OK)
     public Response reissue(HttpServletRequest request, HttpServletResponse response) {
-        authService.reissue(request, response);
-        return Response.success();
+        return Response.success(authService.reissue(request, response));
     }
 
-    @PostMapping("/logout")
+    @PostMapping("/api/auth/logout")
     @ResponseStatus(HttpStatus.OK)
     public Response logout(HttpServletRequest request) {
         authService.logout(request);

--- a/src/main/java/com/soma/snackexercise/controller/signup/SignupController.java
+++ b/src/main/java/com/soma/snackexercise/controller/signup/SignupController.java
@@ -1,11 +1,8 @@
 package com.soma.snackexercise.controller.signup;
 
-import com.soma.snackexercise.auth.jwt.service.JwtService;
 import com.soma.snackexercise.dto.signup.SignupRequest;
-import com.soma.snackexercise.service.member.MemberService;
 import com.soma.snackexercise.service.signup.SignupService;
 import com.soma.snackexercise.util.response.Response;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,13 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class SignupController {
     private final SignupService signupService;
-    private final JwtService jwtService;
 
     @PostMapping("/api/sign-up")
     @ResponseStatus(HttpStatus.CREATED)
-    public Response signup(@RequestBody SignupRequest request, @AuthenticationPrincipal UserDetails loginUser, HttpServletResponse response) {
-        signupService.signup(request, loginUser.getUsername());
-        jwtService.sendAccessAndRefreshByEmail(response, loginUser.getUsername());
+    public Response signup(@RequestBody SignupRequest request, HttpServletResponse response, @AuthenticationPrincipal UserDetails loginUser) {
+        signupService.signup(request, response, loginUser.getUsername());
         return Response.success();
     }
 }

--- a/src/main/java/com/soma/snackexercise/dto/auth/AccessTokenResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/auth/AccessTokenResponse.java
@@ -1,0 +1,12 @@
+package com.soma.snackexercise.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/soma/snackexercise/util/RedisUtil.java
+++ b/src/main/java/com/soma/snackexercise/util/RedisUtil.java
@@ -1,7 +1,6 @@
 package com.soma.snackexercise.util;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Component;
@@ -14,7 +13,7 @@ public class RedisUtil {
     private final RedisTemplate<String, Object> redisTemplate;
     private final RedisTemplate<String, Object> redisBlackListTemplate;
 
-    public void set(String key, Object o, Long minutes) {
+    public void set(String key, Object o, Integer minutes) {
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
         redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
     }
@@ -31,7 +30,7 @@ public class RedisUtil {
         return redisTemplate.hasKey(key);
     }
 
-    public void setBlackList(String key, Object o, Long milliSeconds) {
+    public void setBlackList(String key, Object o, Integer milliSeconds) {
         redisBlackListTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
         redisBlackListTemplate.opsForValue().set(key, o, milliSeconds, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
## 관련 이슈 번호
- close #48 

## 작업사항
- 회원가입, 로그인, reissue일 때 refreshToken cookie httponly로 응답 
- accessToken은 http body json으로 응답

## 변경로직
- 초기에는 JwtAuthenticationProcessingFilter에서 refreshToken 유무에 따라서 AT을 검증할지, AT/RT을 재발급할지 검증 했었음
- refreshToken은 쿠키에 담기므로 AT만 검증하도록 수정
