### PR TITLE
[Feature] 그룹 릴레이 미션 시작 기능 구현

### DIFF
--- a/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/soma/snackexercise/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -3,6 +3,7 @@ package com.soma.snackexercise.auth.jwt.filter;
 import com.soma.snackexercise.auth.jwt.service.JwtService;
 import com.soma.snackexercise.repository.member.MemberRepository;
 import com.soma.snackexercise.util.RedisUtil;
+import com.soma.snackexercise.util.constant.Status;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -39,7 +40,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
         if (jwtService.isTokenValid(accessToken)) {
             jwtService.extractEmail(accessToken)
-                    .ifPresent(email -> memberRepository.findByEmail(email)
+                    .ifPresent(email -> memberRepository.findByEmailAndStatus(email, Status.ACTIVE)
                             .ifPresent(jwtService::saveAuthentication));
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
+++ b/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Exgroup", description = "운동 그룹 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/exgroups")
+@RequestMapping("/api/exgroups")
 public class ExgroupController {
 
     private final ExgroupService exGroupService;
@@ -93,5 +93,13 @@ public class ExgroupController {
     public Response leaveGroupByMember(@PathVariable Long groupId, @AuthenticationPrincipal UserDetails loginUser) {
         exGroupService.leaveGroupByMember(groupId, loginUser.getUsername());
         return Response.success();
+    }
+
+    @Operation(summary = "운동 그룹 시작", description = "운동 그룹을 시작합니다.", security = { @SecurityRequirement(name = "bearer-key") })
+    @Parameter(name = "groupId", description = "시작할 운동 그룹 ID")
+    @PatchMapping("/{groupId}/initiation")
+    @ResponseStatus(HttpStatus.OK)
+    public Response startGroup(@PathVariable("groupId") Long groupId, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(exGroupService.startGroup(groupId, loginUser.getUsername()));
     }
 }

--- a/src/main/java/com/soma/snackexercise/domain/exgroup/Exgroup.java
+++ b/src/main/java/com/soma/snackexercise/domain/exgroup/Exgroup.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
@@ -36,6 +37,12 @@ public class Exgroup extends BaseEntity {
     private LocalTime startTime; // 시작 시간
 
     private LocalTime endTime; // 종료 시간
+
+    private Integer existDays; // 그룹 목표 일수 // TODO 이름 가독성 괜찮은지
+
+    private LocalDate startDate; // 시작 기간
+
+    private LocalDate endDate; // 종료 기간
 
     private String penalty; // 벌칙
 
@@ -71,10 +78,15 @@ public class Exgroup extends BaseEntity {
         this.checkMaxNum = this.getCheckMaxNum();
     }
 
+    public void updateStartDateAndEndDate(){
+        this.startDate = LocalDate.now();
+        this.endDate = startDate.plusDays(existDays);
+    }
+
     @Builder
     public Exgroup(String name, String emozi, String color, String description,
                    Integer maxMemberNum, Integer goalRelayNum, LocalTime startTime,
-                   LocalTime endTime, String penalty, String code, Integer missionIntervalTime,
+                   LocalTime endTime, Integer existDays, String penalty, String code, Integer missionIntervalTime,
                    Integer checkIntervalTime, Integer checkMaxNum) {
         this.name = name;
         this.emozi = emozi;
@@ -84,6 +96,7 @@ public class Exgroup extends BaseEntity {
         this.goalRelayNum = goalRelayNum;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.existDays = existDays;
         this.penalty = penalty;
         this.code = code;
         this.missionIntervalTime = missionIntervalTime;

--- a/src/main/java/com/soma/snackexercise/dto/exgroup/response/ExgroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/exgroup/response/ExgroupResponse.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 
@@ -14,6 +15,7 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExgroupResponse {
+    private Long id;
 
     private String name; // 그룹 이름
 
@@ -33,6 +35,12 @@ public class ExgroupResponse {
     @JsonSerialize(using = LocalTimeSerializer.class)
     private LocalTime endTime; // 종료 시간
 
+    private Integer existDays; // 그룹 목표 일수
+
+    private LocalDate startDate; // 시작 기간
+
+    private LocalDate endDate; // 종료 기간
+
     private String penalty; // 벌칙
 
     private String code; // 그룹 입장 코드
@@ -45,6 +53,7 @@ public class ExgroupResponse {
 
     public static ExgroupResponse toDto(Exgroup exgroup) {
         return new ExgroupResponse(
+                exgroup.getId(),
                 exgroup.getName(),
                 exgroup.getEmozi(),
                 exgroup.getColor(),
@@ -53,6 +62,9 @@ public class ExgroupResponse {
                 exgroup.getGoalRelayNum(),
                 exgroup.getStartTime(),
                 exgroup.getEndTime(),
+                exgroup.getExistDays(),
+                exgroup.getStartDate(),
+                exgroup.getEndDate(),
                 exgroup.getPenalty(),
                 exgroup.getCode(),
                 exgroup.getMissionIntervalTime(),

--- a/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
@@ -168,4 +168,20 @@ public class ExgroupService {
 
         }
     }
+    @Transactional
+    public ExgroupResponse startGroup(Long groupId, String email){
+        Member member = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+        Exgroup exgroup = exgroupRepository.findByIdAndStatus(groupId, Status.ACTIVE).orElseThrow(ExgroupNotFoundException::new);
+
+        // 1. 사용자가 해당 그룹의 방장인지 확인
+        if (!joinListRepository.existsByExgroupAndMemberAndJoinTypeAndStatus(exgroup, member, JoinType.HOST, Status.ACTIVE)) {
+            throw new NotExgroupHostException();
+
+        }
+
+        // 2. 그룹의 시작일자, 끝일자 기록
+        exgroup.updateStartDateAndEndDate();
+
+        return ExgroupResponse.toDto(exgroup);
+    }
 }

--- a/src/main/java/com/soma/snackexercise/service/signup/SignupService.java
+++ b/src/main/java/com/soma/snackexercise/service/signup/SignupService.java
@@ -7,6 +7,7 @@ import com.soma.snackexercise.exception.MemberNameAlreadyExistsException;
 import com.soma.snackexercise.exception.MemberNotFoundException;
 import com.soma.snackexercise.repository.member.MemberRepository;
 
+import com.soma.snackexercise.util.constant.Status;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +22,7 @@ public class SignupService {
 
     public void signup(SignupRequest request, HttpServletResponse response, String email) {
         validateSignup(request);
-        Member findMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Member findMember = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
         findMember.signupMemberInfo(request.getName(), request.getGender(), request.getBirthYear());
 
         String newRefreshToken = jwtService.createRefreshToken(email);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,21 +8,21 @@ INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email,
 INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email, fcmToken, status, createdAt, updatedAt, birthYear) VALUES (7, '박보검', null, 'park', 'MALE', 'KAKAO', 'park@gmail.com', null, 'ACTIVE', '2023-07-21 14:53:29', '2023-07-21 14:53:29', '1993');
 
 -- INSERT EXGROUP
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum) VALUES (2, '운동하자', '', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
-', '105236', '2023-07-21 23:55:26', '2023-07-21 23:55:26', 30, null, 10, 2, '2023-07-21', '2023-08-04', 14);
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum) VALUES (3, '짧고굵게', '', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '운동하자', '', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
+', '105236', '2023-07-21 23:55:26', '2023-07-21 23:55:26', 30, null, 10, 2, NULL, NULL, 14, 14, 'ACTIVE');
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (3, '짧고굵게', '', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
 ', '꼴등 스쿼트 50개 영상찍어 올리기
-', '156398', '2023-07-21 23:58:14', '2023-07-21 23:55:26', 20, null, 10, 3, '2023-07-21', '2023-07-29', 14);
+', '156398', '2023-07-21 23:58:14', '2023-07-21 23:55:26', 20, null, 10, 3, NULL, NULL, 14, 8, 'ACTIVE');
 
 -- INSERT JOINLIST
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (1, 1, 2, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (2, 1, 3, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (3, 2, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (4, 3, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (5, 4, 3, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (6, 5, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (7, 6, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0);
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount) VALUES (8, 7, 2, '2023-07-21 15:06:18', 'MEMBER', '2023-07-21 15:06:18', 0);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (1, 1, 2, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (2, 1, 3, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (3, 2, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (4, 3, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (5, 4, 3, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (6, 5, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (7, 6, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (8, 7, 2, '2023-07-21 15:06:18', 'MEMBER', '2023-07-21 15:06:18', 0, 'ACTIVE');
 
 -- INSERT EXERCISE
 INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, '2023-07-23 11:16:04.000000', 1, '2023-07-23 11:16:03.000000', '어디서나 할 수 있는 전신 운동 입니다


### PR DESCRIPTION
## 관련 이슈 번호
- close #79

## 작업사항
-  Exgroup 엔티티의 시작 일자, 종료 일자 필드 update 기능 구현

## 변경로직
- Exgroup Entity의 시작 일자, 종료 일자, 그룹 목표 일수 필드 추가
- ExgroupResponse에 id, 시작 일자, 종료 일자, 그룹 목표 일수 필드 추가
- controller, service 기능 구현
