### PR TITLE
[Chore] Service layer 함수명 통일, Response Dto에 toDto 함수 생성

### DIFF
--- a/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
+++ b/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
@@ -33,7 +33,7 @@ public class ExgroupController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Response createGroup(@RequestBody PostCreateExgroupRequest groupCreateRequest, @AuthenticationPrincipal UserDetails loginUser){
-        return Response.success(exGroupService.createGroup(groupCreateRequest, loginUser.getUsername()));
+        return Response.success(exGroupService.create(groupCreateRequest, loginUser.getUsername()));
     }
 
 

--- a/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
+++ b/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
@@ -14,15 +14,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 
 @Tag(name = "Member", description = "회원 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
 

--- a/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
+++ b/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 

--- a/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
+++ b/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
@@ -1,10 +1,16 @@
 package com.soma.snackexercise.controller.mission;
 
+import com.soma.snackexercise.dto.mission.response.RankingResponse;
+import com.soma.snackexercise.dto.mission.response.TodayMissionResultResponse;
 import com.soma.snackexercise.exception.WrongRequestParamException;
 import com.soma.snackexercise.service.mission.MissionService;
 import com.soma.snackexercise.util.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -19,17 +25,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class MissionController {
     private final MissionService missionService;
 
-    @Operation(summary = "당일 미션 수행 현황 조회", description = "당일 미션 수행 현황을 조회합니다.", security = { @SecurityRequirement(name = "bearer-key") })
-    @Parameter(name = "exgroupId", description = "조회할 운동 그룹 ID")
+    @Operation(summary = "당일 미션 수행 현황 조회", description = "당일 미션 수행 현황을 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "당일 미션 수행 현황 조회 성공", content = @Content(schema = @Schema(implementation = TodayMissionResultResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "당일 미션 수행 현황을 찾을 수 없음", content = @Content(schema = @Schema(implementation = Response.class)))
+            })
+    @Parameter(name = "groupId", description = "조회할 운동 그룹 ID", required = true,  in = ParameterIn.PATH)
     @GetMapping("/exgroups/{exgroupId}/missions")
     public Response getTodayMissionResults(@PathVariable("exgroupId") Long exgroupId){
         return Response.success(missionService.readTodayMissionResults(exgroupId));
     }
 
 
-    @Operation(summary = "당일 미션 랭킹 조회", description = "미션 랭킹을 조회합니다.", security = { @SecurityRequirement(name = "bearer-key") })
-    @Parameter(name = "exgroupId", description = "조회할 운동 그룹 ID")
-    @Parameter(name = "filter", description = "당일 랭킹 : today, 누적 랭킹 : total")
+    @Operation(summary = "당일 미션 랭킹 조회", description = "미션 랭킹을 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "당일 미션 랭킹 조회 성공", content = @Content(schema = @Schema(implementation = RankingResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "당일 미션 랭킹을 찾을 수 없음", content = @Content(schema = @Schema(implementation = Response.class)))
+            })
+    @Parameter(name = "groupId", description = "조회할 운동 그룹 ID", required = true,  in = ParameterIn.PATH)
+    @Parameter(name = "filter", description = "당일 랭킹 : today, 누적 랭킹 : total", required = true,  in = ParameterIn.QUERY)
     @GetMapping("/exgroups/{exgroupId}/missions/rank")
     public Response getMissionRank(@PathVariable("exgroupId") Long exgroupId, @RequestParam String filter){
         if(filter.equals("today")){
@@ -37,6 +53,6 @@ public class MissionController {
         }else if(filter.equals("total")){
             return Response.success(missionService.readCumulativeMissionRank(exgroupId));
         }
-        throw new WrongRequestParamException();
+        throw new WrongRequestParamException(); // TODO query param 검증을 이런 식으로 해도 될지
     }
 }

--- a/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
+++ b/src/main/java/com/soma/snackexercise/controller/mission/MissionController.java
@@ -23,7 +23,7 @@ public class MissionController {
     @Parameter(name = "exgroupId", description = "조회할 운동 그룹 ID")
     @GetMapping("/exgroups/{exgroupId}/missions")
     public Response getTodayMissionResults(@PathVariable("exgroupId") Long exgroupId){
-        return Response.success(missionService.getTodayMissionResults(exgroupId));
+        return Response.success(missionService.readTodayMissionResults(exgroupId));
     }
 
 
@@ -33,9 +33,9 @@ public class MissionController {
     @GetMapping("/exgroups/{exgroupId}/missions/rank")
     public Response getMissionRank(@PathVariable("exgroupId") Long exgroupId, @RequestParam String filter){
         if(filter.equals("today")){
-            return Response.success(missionService.getTodayMissionRank(exgroupId));
+            return Response.success(missionService.readTodayMissionRank(exgroupId));
         }else if(filter.equals("total")){
-            return Response.success(missionService.getCumulativeMissionRank(exgroupId));
+            return Response.success(missionService.readCumulativeMissionRank(exgroupId));
         }
         throw new WrongRequestParamException();
     }

--- a/src/main/java/com/soma/snackexercise/dto/exgroup/request/PostCreateExgroupRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/exgroup/request/PostCreateExgroupRequest.java
@@ -2,9 +2,7 @@ package com.soma.snackexercise.dto.exgroup.request;
 
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,11 +25,9 @@ public class PostCreateExgroupRequest {
 
     private Integer goalRelayNum; // 목표 릴레이 횟수
 
-    @JsonSerialize(using = LocalTimeSerializer.class)
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     private LocalTime startTime; // 시작 시간
 
-    @JsonSerialize(using = LocalTimeSerializer.class)
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     private LocalTime endTime; // 종료 시간
 

--- a/src/main/java/com/soma/snackexercise/dto/exgroup/response/PostCreateExgroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/exgroup/response/PostCreateExgroupResponse.java
@@ -1,5 +1,6 @@
 package com.soma.snackexercise.dto.exgroup.response;
 
+import com.soma.snackexercise.domain.exgroup.Exgroup;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,4 +11,11 @@ import lombok.NoArgsConstructor;
 public class PostCreateExgroupResponse {
     private Long id;
     private String name;
+
+    public static PostCreateExgroupResponse toDto(Exgroup exgroup) {
+        return new PostCreateExgroupResponse(
+                exgroup.getId(),
+                exgroup.getName()
+        );
+    }
 }

--- a/src/main/java/com/soma/snackexercise/dto/member/response/GetOneGroupMemberResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/member/response/GetOneGroupMemberResponse.java
@@ -1,6 +1,8 @@
 package com.soma.snackexercise.dto.member.response;
 
+import com.soma.snackexercise.domain.joinlist.JoinList;
 import com.soma.snackexercise.domain.joinlist.JoinType;
+import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.util.constant.Status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,5 +19,14 @@ public class GetOneGroupMemberResponse {
     private JoinType joinType;
 
     private Status status;
+
+    public static GetOneGroupMemberResponse toDto(Member member, JoinList joinList) {
+        return new GetOneGroupMemberResponse(
+                member.getProfileImage(),
+                member.getNickname(),
+                joinList.getJoinType(),
+                joinList.getStatus()
+        );
+    }
 
 }

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
@@ -1,5 +1,6 @@
 package com.soma.snackexercise.dto.mission.response;
 
+import com.soma.snackexercise.domain.mission.Mission;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,4 +14,14 @@ public class MemberMissionDto {
     private String profileImage;
     private LocalDateTime startAt;
     private LocalDateTime endAt;
+
+    public static MemberMissionDto toDto(Mission mission) {
+        return new MemberMissionDto(
+                mission.getMember().getId(),
+                mission.getMember().getNickname(),
+                mission.getMember().getProfileImage(),
+                mission.getStartAt(),
+                mission.getEndAt()
+        );
+    }
 }

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/RankingResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/RankingResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class RankingResponseDto {
+public class RankingResponse {
     private String nickname;
     private String profileImage;
     private long avgMissionExecutionTime; // 미션 평균 반응 속도

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/TodayMissionResultResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/TodayMissionResultResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @AllArgsConstructor
 @Getter
-public class TodayMissionCurrentResultDto {
+public class TodayMissionResultResponse {
     private List<MemberMissionDto> missionFlow;
     private Integer finishedRelayCount; // 현재까지 완료한 릴레이 횟수
     private LocalDate exgroupEndDate; // 그룹 종료 일자

--- a/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
@@ -35,7 +35,7 @@ public class ExgroupService {
 
 
     @Transactional
-    public PostCreateExgroupResponse createGroup(PostCreateExgroupRequest groupCreateRequest, String email){
+    public PostCreateExgroupResponse create(PostCreateExgroupRequest groupCreateRequest, String email){
 
         // 1. 그룹 생성할 회원 조회
         Member member = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
@@ -71,7 +71,7 @@ public class ExgroupService {
 
         exgroupRepository.save(newGroup);
 
-        // 5. 회원이 그룹 연결
+        // 5. 회원과 그룹 연결
         JoinList joinRequest = JoinList.builder()
                 .member(member)
                 .exgroup(newGroup)

--- a/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
@@ -79,7 +79,7 @@ public class ExgroupService {
                 .build();
 
         joinListRepository.save(joinRequest);
-        return new PostCreateExgroupResponse(newGroup.getId(), newGroup.getName());
+        return PostCreateExgroupResponse.toDto(newGroup);
     }
 
     public ExgroupResponse findGroup(Long groupId){
@@ -91,7 +91,7 @@ public class ExgroupService {
     public List<GetOneGroupMemberResponse> getAllExgroupMembers(Long groupId){
         List<JoinListMemberDto> allGroupMembers = memberRepository.findAllGroupMembers(groupId);
 
-        return allGroupMembers.stream().map(data -> new GetOneGroupMemberResponse(data.getMember().getProfileImage(), data.getMember().getNickname(), data.getJoinList().getJoinType(), data.getJoinList().getStatus())).toList();
+        return allGroupMembers.stream().map(data -> GetOneGroupMemberResponse.toDto(data.getMember(), data.getJoinList())).toList();
     }
 
     @Transactional

--- a/src/main/java/com/soma/snackexercise/service/member/MemberService.java
+++ b/src/main/java/com/soma/snackexercise/service/member/MemberService.java
@@ -1,7 +1,9 @@
 package com.soma.snackexercise.service.member;
 
 import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.dto.member.JoinListMemberDto;
 import com.soma.snackexercise.dto.member.request.MemberUpdateRequest;
+import com.soma.snackexercise.dto.member.response.GetOneGroupMemberResponse;
 import com.soma.snackexercise.dto.member.response.MemberResponse;
 import com.soma.snackexercise.exception.MemberNameAlreadyExistsException;
 import com.soma.snackexercise.exception.MemberNotFoundException;
@@ -10,6 +12,8 @@ import com.soma.snackexercise.util.constant.Status;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -4,8 +4,8 @@ import com.soma.snackexercise.domain.exgroup.Exgroup;
 import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.domain.mission.Mission;
 import com.soma.snackexercise.dto.mission.response.MemberMissionDto;
-import com.soma.snackexercise.dto.mission.response.RankingResponseDto;
-import com.soma.snackexercise.dto.mission.response.TodayMissionCurrentResultDto;
+import com.soma.snackexercise.dto.mission.response.RankingResponse;
+import com.soma.snackexercise.dto.mission.response.TodayMissionResultResponse;
 import com.soma.snackexercise.exception.ExgroupNotFoundException;
 import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
 import com.soma.snackexercise.repository.mission.MissionRepository;
@@ -28,7 +28,7 @@ public class MissionService {
     private final MissionRepository missionRepository;
     private final ExgroupRepository exgroupRepository;
 
-    public TodayMissionCurrentResultDto readTodayMissionResults(Long exgroupId) {
+    public TodayMissionResultResponse readTodayMissionResults(Long exgroupId) {
         // 1. 그룹의 종료일자
         Exgroup exgroup = exgroupRepository.findById(exgroupId).orElseThrow(ExgroupNotFoundException::new);
 
@@ -43,7 +43,7 @@ public class MissionService {
         List<Mission> missions = missionRepository.findAllMissionByGroupIdAndCreatedAt(exgroupId, todayMidnight, tomorrowMidnight);
         List<MemberMissionDto> missionFlow = missions.stream().map(mission -> new MemberMissionDto(mission.getMember().getId(), mission.getMember().getNickname(), mission.getMember().getProfileImage(), mission.getCreatedAt(), mission.getEndAt())).toList();
 
-        return new TodayMissionCurrentResultDto(missionFlow, currentFinishedRelayCount, exgroup.getEndDate());
+        return new TodayMissionResultResponse(missionFlow, currentFinishedRelayCount, exgroup.getEndDate());
     }
 
     public Object readTodayMissionRank(Long exgroupId) {
@@ -67,9 +67,9 @@ public class MissionService {
         return calcRankFromMissionList(missions);
     }
 
-    private static List<RankingResponseDto> calcRankFromMissionList(List<Mission> missions) {
+    private static List<RankingResponse> calcRankFromMissionList(List<Mission> missions) {
         // 1. memberId 별로 평균 속도 계산
-        Map<Long, RankingResponseDto> todayRankingMap = new HashMap<>();
+        Map<Long, RankingResponse> todayRankingMap = new HashMap<>();
 
         for (Mission mission : missions) {
             Long memberId = mission.getMember().getId();
@@ -77,7 +77,7 @@ public class MissionService {
 
             if(!todayRankingMap.containsKey(memberId)){
                 Member member = mission.getMember();
-                todayRankingMap.put(memberId, new RankingResponseDto(member.getName(), member.getProfileImage(), minutesDiffBetweenCreateAndStart, 1));
+                todayRankingMap.put(memberId, new RankingResponse(member.getName(), member.getProfileImage(), minutesDiffBetweenCreateAndStart, 1));
             }else{
                 todayRankingMap.get(memberId).addTime(minutesDiffBetweenCreateAndStart);
             }

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -41,7 +41,7 @@ public class MissionService {
 
         // 3. 모든 그룹원의 오늘 수행한 미션 현황
         List<Mission> missions = missionRepository.findAllMissionByGroupIdAndCreatedAt(exgroupId, todayMidnight, tomorrowMidnight);
-        List<MemberMissionDto> missionFlow = missions.stream().map(mission -> new MemberMissionDto(mission.getMember().getId(), mission.getMember().getNickname(), mission.getMember().getProfileImage(), mission.getCreatedAt(), mission.getEndAt())).toList();
+        List<MemberMissionDto> missionFlow = missions.stream().map(mission -> MemberMissionDto.toDto(mission)).toList();
 
         return new TodayMissionResultResponse(missionFlow, currentFinishedRelayCount, exgroup.getEndDate());
     }


### PR DESCRIPTION
## 관련 이슈 번호
- close #76

## 작업사항
- 이름, toDto 함수를 사용해 코드 가독성 높임

## 변경로직
- Service 클래스의 함수명을 create, read, update, delete로 통일
- Request Dto의 JsonSerialize 삭제
- Swagger 명세서 추가
- 반환시 사용하는 DTO 클래스 명 ResponseDto에서 Response로 수정
- Response Dto에 toDto 메소드 작성하여, Service 클래스에서의 코드 가독성 높임
