### PR TITLE
fix : 백엔드 서버 도메인 변경에 따른 swagger 도메인 수정(#76)

### DIFF
--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev.snackexercise.com")})
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev-api.snackexercise.com")})
 @EnableJpaAuditing
 @SpringBootApplication
 public class SnackExerciseApplication {


### PR DESCRIPTION
## 작업사항
- 백엔드 서버 도메인 변경에 따라 swagger 도메인을 수정하였습니다.

## 변경로직
- 백엔드 서버 도메인을 dev.snackexercise.com에서 dev-api.snackexercise.com으로 수정하였습니다.