### PR TITLE
[Fix] Exgroup, JoinList 엔티티 필드 추가 및 삭제

### DIFF
--- a/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
+++ b/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
@@ -28,6 +28,8 @@ public class JoinList extends BaseEntity {
 
     private Integer outCount;
 
+    private Integer executedMissionCount;
+
     public void addOneOutCount() {
         this.outCount += 1;
     }
@@ -42,6 +44,7 @@ public class JoinList extends BaseEntity {
         this.exgroup = exgroup;
         this.joinType = joinType;
         this.outCount = 0;
+        this.executedMissionCount = 0;
         active();
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,21 +8,21 @@ INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email,
 INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email, fcmToken, status, createdAt, updatedAt, birthYear) VALUES (7, '박보검', null, 'park', 'MALE', 'KAKAO', 'park@gmail.com', null, 'ACTIVE', '2023-07-21 14:53:29', '2023-07-21 14:53:29', '1993');
 
 -- INSERT EXGROUP
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '운동하자', '', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
-', '105236', '2023-07-21 23:55:26', '2023-07-21 23:55:26', 30, null, 10, 2, NULL, NULL, 14, 14, 'ACTIVE');
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, missionIntervalTime, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (3, '짧고굵게', '', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '운동하자', '', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
+', '105236', '2023-07-21 23:55:26', '2023-07-21 23:55:26', null, 10, 2, NULL, NULL, 14, 14, 'ACTIVE');
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (3, '짧고굵게', '', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
 ', '꼴등 스쿼트 50개 영상찍어 올리기
-', '156398', '2023-07-21 23:58:14', '2023-07-21 23:55:26', 20, null, 10, 3, NULL, NULL, 14, 8, 'ACTIVE');
+', '156398', '2023-07-21 23:58:14', '2023-07-21 23:55:26', null, 10, 3, NULL, NULL, 14, 8, 'ACTIVE');
 
 -- INSERT JOINLIST
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (1, 1, 2, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (2, 1, 3, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (3, 2, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (4, 3, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (5, 4, 3, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (6, 5, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (7, 6, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE');
-INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status) VALUES (8, 7, 2, '2023-07-21 15:06:18', 'MEMBER', '2023-07-21 15:06:18', 0, 'ACTIVE');
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (1, 1, 2, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE', 0);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (2, 1, 3, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (3, 2, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (4, 3, 2, '2023-07-21 15:05:14', 'MEMBER', '2023-07-21 15:05:14', 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (5, 4, 3, '2023-07-21 15:05:14', 'HOST', '2023-07-21 15:05:14', 0, 'ACTIVE', 0);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (6, 5, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (7, 6, 2, '2023-07-21 15:05:54', 'MEMBER', '2023-07-21 15:05:54', 0, 'ACTIVE', 0);
+INSERT INTO JoinList (id, memberId, exgroupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (8, 7, 2, '2023-07-21 15:06:18', 'MEMBER', '2023-07-21 15:06:18', 0, 'ACTIVE', 0);
 
 -- INSERT EXERCISE
 INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, '2023-07-23 11:16:04.000000', 1, '2023-07-23 11:16:03.000000', '어디서나 할 수 있는 전신 운동 입니다


### PR DESCRIPTION
## 작업사항
- Exgroup, JoinList 엔티티 필드 추가 및 삭제

## 변경로직
- Exgroup - missionIntervalTime(미션 수행 간격) 필드 삭제에 따라 더미데이터에서도 해당 컬럼 삭제
- JoinList - executedMissionCount(현재수행완료한 미션 개수) 필드 추가
