### PR TITLE
[Fix] 모든 url에 대해서 security 적용

### DIFF
--- a/src/main/java/com/soma/snackexercise/config/SecurityConfig.java
+++ b/src/main/java/com/soma/snackexercise/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(request -> request.requestMatchers("/**",
+                .authorizeHttpRequests(request -> request.requestMatchers(
                         "/error", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**",
                         "/sign-up", "/api/auth/**", "/health").permitAll()
                         .anyRequest().authenticated())


### PR DESCRIPTION
## 작업사항
- 작업의 편리성을 위해서 모든 url에 대해서 security를 해제했었으나, post 요청시 @AuthenticationPrincipal의 값으로 null이 넘어오는 에러가 발생하여 모든 url에 대해서 security를 적용하도록 변경하였습니다.

## 변경로직
- security 에서 `/**`에 대한 permitAll 삭제
