### PR TITLE
[Feature] docker-compose

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -81,8 +81,6 @@ jobs:
           key: ${{ secrets.KEY }}
           port: 22
           script: |
-            sudo docker stop spring-dev
-            sudo docker rm spring-dev
+            sudo docker-compose down
             sudo docker image rm ${{ secrets.DOCKER_REPO }}
-            sudo docker pull ${{ secrets.DOCKER_REPO }}:latest-dev
-            sudo docker run -d --name spring-dev -p 8080:8080 -e spring.profiles.active=dev-env ${{ secrets.DOCKER_REPO }}:latest-dev
+            sudo docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3' # docker-compose는 버전 1~3까지 존재, 최신 버전 사용을 위해서 버전 3 설정
+
+services: # 컨테이너 집합 요소
+  redis:
+    container_name: snack-redis
+    hostname: redis
+    image: redis
+    ports:
+      - 6379:6379
+    networks:
+      - snack_net
+
+  springboot:
+    container_name: spring-dev
+    # build:
+    #  context: . # DockerFile이 있는 디렉토리
+    #  dockerfile: Dockerfile
+    image: ojs835/snack-exercise-hub:latest-dev
+    ports:
+      - 8080:8080
+    depends_on:
+      - redis
+    environment:
+      SPRING_PROFILES_ACTIVE : dev-env # 사용할 profile 지정
+    networks:
+      - snack_net
+
+networks:
+  snack_net:
+    driver: bridge


### PR DESCRIPTION
## 관련 이슈 번호
- close #94

## 작업사항
- docker-compose를 사용하여 redis와 spring boot application 2개의 컨테이너를 관리합니다.
- docker는 각 컨테이너 별로 IP가 생성됩니다. 따라서 spring boot의 yml 파일에서 `spring:data:redis:host : localhost`로 설정시 이는 redis container의 localhost가 아닌 spring boot의 localhost를 의미합니다.
- 이를 위해 docker compose에 spring boot 애플리케이션과 redis 컨테이너를 연결해주는 network를 생성합니다. 
- 네트워크로 연결된 컨테이너들은 컨테이너명으로 해당 컨테이너의 네트워크 접속이 가능합니다. 따라서 `spring:data:redis:host : redis컨테이너명` 으로 수정하여 연결을 성공적으로 수행할 수 있도록 수정하였습니다.

## 변경로직
- docker-compose.yml 작성
- dev-deploy.yml docker-compose 버전으로 수정
- application-oauth.yml 파일 수정 (redis의 host)
