### PR TITLE
[Test] 운동 그룹 ControllerAcvice, 통합 테스트

### DIFF
--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -10,20 +10,25 @@ public enum ErrorCode {
     TOKEN_EXPIRED_EXCEPTION(-1000, "토큰이 만료되었습니다."),
 
     /* Member */
-    MEMBER_NAME_ALREADY_EXISTS_EXCEPTION(-1100, "유저 이름이 이미 존재합니다."),
+    MEMBER_NOT_FOUND_EXCEPTION(-1100, "사용자가 존재하지 않습니다."),
+    MEMBER_NAME_ALREADY_EXISTS_EXCEPTION(-1101, "유저 이름이 이미 존재합니다."),
 
     /* Exgroup */
-    NOT_FOUND_EXGROUP(1200, "운동 그룹이 존재하지 않습니다."),
+    // todo : 너무 에러메시지가 친절한가..?
+    EXGROUP_NOT_FOUND_EXCEPTION(-1200, "운동 그룹이 존재하지 않습니다."),
+    NOT_EXGROUP_HOST_EXCEPTION(-1201, "운동 그룹의 방장 권한이 아닙니다."),
+    NOT_EXGROUP_MEMBER_EXCEPTION(-1202, "운동 그룹의 멤버 권한이 아닙니다."),
+
+    /* JoinList */
+    JOIN_LIST_NOT_FOUND_EXCEPTION(-1300, "회원_운동그룹이 존재하지 않습니다."),
 
     /* QueryParam */
-    WRONG_QUERYPARAM(1900, "잘못된 Query Param입니다.");
+    WRONG_QUERY_PARAM_EXCEPTION(-1900, "잘못된 Query Param입니다.");
 
     ErrorCode(int code, String message){
         this.code = code;
         this.message = message;
     }
-
-
 
     private int code;
     private String message;

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -1,12 +1,12 @@
 package com.soma.snackexercise.advice;
 
 import com.auth0.jwt.exceptions.TokenExpiredException;
-import com.soma.snackexercise.exception.ExgroupNotFoundException;
-import com.soma.snackexercise.exception.MemberNameAlreadyExistsException;
-import com.soma.snackexercise.exception.WrongRequestParamException;
+import com.soma.snackexercise.exception.*;
 import com.soma.snackexercise.util.response.Response;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.soma.snackexercise.advice.ErrorCode.*;
@@ -18,7 +18,8 @@ public class ExceptionAdvice {
     Authorization
      */
     @ExceptionHandler(TokenExpiredException.class)
-    public Response tokenExpiredException(TokenExpiredException e) {
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public Response tokenExpiredExceptionHandler(TokenExpiredException e) {
         return Response.failure(TOKEN_EXPIRED_EXCEPTION);
     }
 
@@ -26,8 +27,15 @@ public class ExceptionAdvice {
     /*
     Member
      */
+    @ExceptionHandler(MemberNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response memberNotFoundExceptionHandler(MemberNotFoundException e) {
+        return Response.failure(MEMBER_NOT_FOUND_EXCEPTION);
+    }
+
     @ExceptionHandler(MemberNameAlreadyExistsException.class)
-    public Response memberNameAlreadyExistsException(MemberNameAlreadyExistsException e) {
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Response memberNameAlreadyExistsExceptionHandler(MemberNameAlreadyExistsException e) {
         return Response.failure(MEMBER_NAME_ALREADY_EXISTS_EXCEPTION);
     }
 
@@ -35,15 +43,38 @@ public class ExceptionAdvice {
     Exgroup
      */
     @ExceptionHandler(ExgroupNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     public Response exgroupNotFoundExceptionHandler(ExgroupNotFoundException e){
-        return Response.failure(NOT_FOUND_EXGROUP);
+        return Response.failure(EXGROUP_NOT_FOUND_EXCEPTION);
+    }
+
+    @ExceptionHandler(NotExgroupHostException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public Response notExgroupHostExceptionHandler (NotExgroupHostException e){
+        return Response.failure(NOT_EXGROUP_HOST_EXCEPTION);
+    }
+
+    @ExceptionHandler(NotExgroupMemberException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public Response notExgroupMemberExceptionHandler (NotExgroupMemberException e){
+        return Response.failure(NOT_EXGROUP_MEMBER_EXCEPTION);
+    }
+
+    /*
+    JoinList
+     */
+    @ExceptionHandler(JoinListNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response joinListNotFoundExceptionHandler (JoinListNotFoundException e){
+        return Response.failure(JOIN_LIST_NOT_FOUND_EXCEPTION);
     }
 
     /*
     Query Param
      */
     @ExceptionHandler(WrongRequestParamException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Response wrongRequestParamExceptionHandler(WrongRequestParamException e){
-        return Response.failure(WRONG_QUERYPARAM);
+        return Response.failure(WRONG_QUERY_PARAM_EXCEPTION);
     }
 }

--- a/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
+++ b/src/main/java/com/soma/snackexercise/controller/exgroup/ExgroupController.java
@@ -32,7 +32,7 @@ public class ExgroupController {
     @Operation(summary = "운동 그룹 생성", description = "하나의 운동 그룹을 생성합니다.", security = { @SecurityRequirement(name = "bearer-key") })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Response createGroup(@RequestBody ExgroupCreateRequest groupCreateRequest, @AuthenticationPrincipal UserDetails loginUser){
+    public Response create(@RequestBody ExgroupCreateRequest groupCreateRequest, @AuthenticationPrincipal UserDetails loginUser){
         return Response.success(exGroupService.create(groupCreateRequest, loginUser.getUsername()));
     }
 
@@ -41,14 +41,14 @@ public class ExgroupController {
     @Parameter(name = "groupId", description = "조회할 운동 그룹 ID")
     @GetMapping("/{groupId}")
     @ResponseStatus(HttpStatus.OK)
-    public Response findGroup(@PathVariable("groupId") Long groupId){
+    public Response read(@PathVariable("groupId") Long groupId){
         return Response.success(exGroupService.read(groupId));
     }
 
     @Operation(summary = "하나의 운동 그룹에 속한 모든 회원 조회", description = "하나의 운동 그룹에 속한 모든 회원을 조회합니다.", security = { @SecurityRequirement(name = "bearer-key") })
     @Parameter(name = "groupId", description = "조회할 운동 그룹 ID")
     @GetMapping("/{groupId}/members")
-    public Response getAllExgroupMembers(@PathVariable("groupId") Long groupId){
+    public Response readAllMembers(@PathVariable("groupId") Long groupId){
         return Response.success(exGroupService.getAllExgroupMembers(groupId));
     }
 

--- a/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerAdviceTest.java
+++ b/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerAdviceTest.java
@@ -1,0 +1,171 @@
+package com.soma.snackexercise.controller.exgroup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.snackexercise.advice.ExceptionAdvice;
+import com.soma.snackexercise.config.TestUserArgumentResolver;
+import com.soma.snackexercise.dto.exgroup.request.ExgroupCreateRequest;
+import com.soma.snackexercise.dto.exgroup.request.ExgroupUpdateRequest;
+import com.soma.snackexercise.exception.*;
+import com.soma.snackexercise.service.exgroup.ExgroupService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static com.soma.snackexercise.advice.ErrorCode.*;
+import static com.soma.snackexercise.factory.dto.ExgroupCreateFactory.createExgroupCreateRequest;
+import static com.soma.snackexercise.factory.dto.ExgroupUpdateFactory.createExgroupUpdateRequest;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class ExgroupControllerAdviceTest {
+    @InjectMocks
+    private ExgroupController exgroupController;
+
+    @Mock
+    private ExgroupService exgroupService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(exgroupController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .setControllerAdvice(new ExceptionAdvice())
+                .build();
+    }
+
+    @Test
+    @DisplayName("운동 그룹 생성 메소드에서 MemberNotFoundException 발생시 적절한 응답을 반환하는지 테스트")
+    void createMemberNotFoundExceptionTest() throws Exception {
+        // given
+        ExgroupCreateRequest request = createExgroupCreateRequest();
+        given(exgroupService.create(any(), anyString())).willThrow(MemberNotFoundException.class);
+
+        // when, then
+        mockMvc.perform(
+                        post("/api/exgroups")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andExpect(jsonPath("$.code").value(MEMBER_NOT_FOUND_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(MEMBER_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹 조회 메소드에서 ExgroupNotFoundExceptionTest 발생시 적절한 응답을 반환하는지 테스트")
+    void readExgroupNotFoundExceptionTest() throws Exception {
+        // given
+        Long groupId = 1L;
+        given(exgroupService.read(anyLong())).willThrow(ExgroupNotFoundException.class);
+
+        // when, then
+        mockMvc.perform(
+                        get("/api/exgroups/{groupId}", groupId)
+                ).andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(EXGROUP_NOT_FOUND_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(EXGROUP_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹 수정 메소드에서 NotExgroupHostException 발생시 적절한 응답을 반환하는지 테스트")
+    void updateNotExgroupHostExceptionTest() throws Exception {
+        // given
+        Long groupId = 1L;
+        ExgroupUpdateRequest request = createExgroupUpdateRequest();
+        given(exgroupService.update(anyLong(), anyString(), any())).willThrow(NotExgroupHostException.class);
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/exgroups/{groupId}", groupId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(NOT_EXGROUP_HOST_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(NOT_EXGROUP_HOST_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹에서 방장이 회원 강퇴 메소드에서 JoinListNotFoundException 발싱시 적절한 응답을 반환하는지 테스트")
+    void deleteMemberByHostJoinListNotFoundExceptionTest() throws Exception {
+        // given
+        Long groupId = 1L;
+        Long memberId = 1L;
+        doThrow(JoinListNotFoundException.class).when(exgroupService).deleteMemberByHost(anyLong(), anyLong(), anyString());
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/exgroups/{groupId}/members/{memberId}", groupId, memberId)
+                ).andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(JOIN_LIST_NOT_FOUND_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(JOIN_LIST_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹에서 방장이 회원 강퇴 메소드에서 NotExgroupMemberException 발싱시 적절한 응답을 반환하는지 테스트")
+    void deleteMemberByHostNotExgroupMemberExceptionExceptionTest() throws Exception {
+        // given
+        Long groupId = 1L;
+        Long memberId = 1L;
+        doThrow(NotExgroupMemberException.class).when(exgroupService).deleteMemberByHost(anyLong(), anyLong(), anyString());
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/exgroups/{groupId}/members/{memberId}", groupId, memberId)
+                ).andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(NOT_EXGROUP_MEMBER_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(NOT_EXGROUP_MEMBER_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("회원이 운동 그룹을 탈퇴하는 메소드에서 JoinListNotFoundException 발싱시 적절한 응답을 반환하는지 테스트")
+    void leaveGroupByMemberJoinListNotFoundExceptionTest () throws Exception {
+        // given
+        Long groupId = 1L;
+        doThrow(JoinListNotFoundException.class).when(exgroupService).leaveGroupByMember(anyLong(), anyString());
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/exgroups/{groupId}", groupId)
+                ).andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(JOIN_LIST_NOT_FOUND_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(JOIN_LIST_NOT_FOUND_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹 시작 메소드에서 NotExgroupHostException 발싱시 적절한 응답을 반환하는지 테스트")
+    void startGroupNotExgroupHostExceptionTest () throws Exception {
+        // given
+        Long groupId = 1L;
+        given(exgroupService.startGroup(anyLong(), anyString())).willThrow(NotExgroupHostException.class);
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/exgroups/{groupId}/initiation", groupId)
+                ).andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(NOT_EXGROUP_HOST_EXCEPTION.getCode()))
+                .andExpect(jsonPath("$.result.message").value(NOT_EXGROUP_HOST_EXCEPTION.getMessage()));
+    }
+}

--- a/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerIntegrationTest.java
+++ b/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerIntegrationTest.java
@@ -1,0 +1,237 @@
+package com.soma.snackexercise.controller.exgroup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soma.snackexercise.domain.exgroup.Exgroup;
+import com.soma.snackexercise.domain.joinlist.JoinList;
+import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.dto.exgroup.request.ExgroupCreateRequest;
+import com.soma.snackexercise.dto.exgroup.request.ExgroupUpdateRequest;
+import com.soma.snackexercise.exception.ExgroupNotFoundException;
+import com.soma.snackexercise.exception.JoinListNotFoundException;
+import com.soma.snackexercise.init.TestInitDB;
+import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
+import com.soma.snackexercise.repository.joinlist.JoinListRepository;
+import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.util.constant.Status;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static com.soma.snackexercise.factory.dto.ExgroupCreateFactory.createExgroupCreateRequest;
+import static com.soma.snackexercise.factory.dto.ExgroupUpdateFactory.createExgroupUpdateRequest;
+import static com.soma.snackexercise.factory.entity.ExgroupFactory.createExgroup;
+import static com.soma.snackexercise.factory.entity.JoinListFactory.createJoinListForHost;
+import static com.soma.snackexercise.factory.entity.JoinListFactory.createJoinListForMember;
+import static com.soma.snackexercise.factory.entity.MemberFactory.createMember;
+import static com.soma.snackexercise.factory.entity.MemberFactory.createMemberWithEmail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("ExgroupController 통합 테스트")
+public class ExgroupControllerIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private ExgroupRepository exgroupRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JoinListRepository joinListRepository;
+
+    @Autowired
+    private TestInitDB initDB;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private Member member;
+
+    private static String email = "test";
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+
+        // security 인증 정보를 제공하기 위한 유저 정보 저장
+        member = memberRepository.save(createMemberWithEmail(email));
+    }
+
+    @Test
+    @DisplayName("운동 그룹 생성 API 테스트")
+    @WithMockUser(username = "test")
+    void createTest() throws Exception {
+        // given
+        ExgroupCreateRequest request = createExgroupCreateRequest();
+        int beforeSize = exgroupRepository.findAll().size();
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        post("/api/exgroups")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.result.data.name").value(request.getName()));
+
+        int afterSize = exgroupRepository.findAll().size();
+        assertThat(afterSize).isEqualTo(beforeSize + 1);
+    }
+
+    @Test
+    @DisplayName("운동 그룹 조회 API 테스트")
+    @WithMockUser(username = "test")
+    void readTest() throws Exception {
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        get("/api/exgroups/{groupId}", exgroup.getId())
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result.data.id").value(exgroup.getId()))
+                .andExpect(jsonPath("$.result.data.name").value(exgroup.getName()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹에 속한 모든 회원 조회 API 테스트")
+    @WithMockUser(username = "test")
+    void readAllMembersTest() throws Exception{
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        Member member1 = memberRepository.save(createMember());
+        Member member2 = memberRepository.save(createMember());
+        joinListRepository.save(createJoinListForHost(member1, exgroup));
+        joinListRepository.save(createJoinListForMember(member2, exgroup));
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        get("/api/exgroups/{groupId}/members", exgroup.getId())
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.data", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("운동 그룹 수정 API 테스트")
+    @WithMockUser(username = "test")
+    void updateTest() throws Exception {
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        joinListRepository.save(createJoinListForHost(member, exgroup));
+        ExgroupUpdateRequest request = createExgroupUpdateRequest();
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/exgroups/{groupId}", exgroup.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.data.name").value(request.getName()));
+    }
+
+    @Test
+    @DisplayName("운동 그룹에서 방장이 회원 탈퇴시키는 API 테스트")
+    @WithMockUser(username = "test")
+    void deleteMemberByHostTest() throws Exception {
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        Member targetMember = memberRepository.save(createMember());
+        JoinList hostJoinList = joinListRepository.save(createJoinListForHost(member, exgroup));
+        JoinList targetMemberJoinList = joinListRepository.save(createJoinListForMember(targetMember, exgroup));
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/exgroups/{groupId}/members/{memberId}", exgroup.getId(), targetMember.getId())
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        JoinList updatedTargetMemberJoinList = joinListRepository.findById(targetMemberJoinList.getId()).orElseThrow(JoinListNotFoundException::new);
+        assertThat(hostJoinList.getStatus()).isEqualTo(Status.ACTIVE);
+        assertThat(updatedTargetMemberJoinList.getStatus()).isEqualTo(Status.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("회원이 운동 그룹을 탈퇴하는 API 테스트")
+    @WithMockUser(username = "test")
+    void leaveGroupByMemberTest() throws Exception {
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        JoinList joinList = joinListRepository.save(createJoinListForMember(member, exgroup));
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        delete("/api/exgroups/{groupId}", exgroup.getId())
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        JoinList updatedJoinList = joinListRepository.findById(joinList.getId()).orElseThrow(JoinListNotFoundException::new);
+        assertThat(updatedJoinList.getStatus()).isEqualTo(Status.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("방장이 운동 그룹 시작하는 API 테스트")
+    @WithMockUser(username = "test")
+    void startGroupTest() throws Exception {
+        // given
+        Exgroup exgroup = exgroupRepository.save(createExgroup());
+        joinListRepository.save(createJoinListForHost(member, exgroup));
+        clear();
+
+        // when, then
+        mockMvc.perform(
+                        patch("/api/exgroups/{groupId}/initiation", exgroup.getId())
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result.data.name").value(exgroup.getName()));
+
+        assertNull(exgroup.getStartDate());
+        Exgroup updatedExgroup = exgroupRepository.findByIdAndStatus(exgroup.getId(), Status.ACTIVE).orElseThrow(ExgroupNotFoundException::new);
+        assertNotNull(updatedExgroup.getStartDate());
+        assertNotNull(updatedExgroup.getEndDate());
+    }
+
+    void clear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerTest.java
+++ b/src/test/java/com/soma/snackexercise/controller/exgroup/ExgroupControllerTest.java
@@ -57,7 +57,7 @@ class ExgroupControllerTest {
 
     @Test
     @DisplayName("운동 그룹 생성 메소드 동작 성공 테스트")
-    void createGroupTest() throws Exception {
+    void createTest() throws Exception {
         // given
         ExgroupCreateRequest request = createExgroupCreateRequest();
 
@@ -73,7 +73,7 @@ class ExgroupControllerTest {
 
     @Test
     @DisplayName("하나의 그룹 조회 메소드 동작 성공 테스트")
-    void findGroupTest() throws Exception {
+    void readTest() throws Exception {
         // given
         Long groupId = 1L;
 
@@ -87,7 +87,7 @@ class ExgroupControllerTest {
 
     @Test
     @DisplayName("하나의 운동 그룹에 속한 모든 회원 조회 메소드 동작 성공 테스트")
-    void getAllExgroupMembersTest() throws Exception {
+    void readAllMembersTest() throws Exception {
         // given
         Long groupId = 1L;
         List<GetOneGroupMemberResponse> groupMembers = Arrays.asList(createGetOneGroupMemberResponse(), createGetOneGroupMemberResponse());

--- a/src/test/java/com/soma/snackexercise/factory/dto/ExgroupCreateFactory.java
+++ b/src/test/java/com/soma/snackexercise/factory/dto/ExgroupCreateFactory.java
@@ -7,6 +7,6 @@ import java.time.LocalTime;
 public class ExgroupCreateFactory {
     public static ExgroupCreateRequest createExgroupCreateRequest() {
         return new ExgroupCreateRequest("name", "emozi", "color", "description", 3, 10,
-                LocalTime.now(), LocalTime.now().plusHours(1), "커피 쏘기", 20, 2, 10);
+                LocalTime.of(9, 0), LocalTime.of(10, 0), "커피 쏘기", 20, 2, 10);
     }
 }

--- a/src/test/java/com/soma/snackexercise/init/TestInitDB.java
+++ b/src/test/java/com/soma/snackexercise/init/TestInitDB.java
@@ -1,0 +1,29 @@
+package com.soma.snackexercise.init;
+
+import com.soma.snackexercise.domain.exgroup.Exgroup;
+import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.soma.snackexercise.factory.entity.ExgroupFactory.createExgroup;
+
+@Component
+public class TestInitDB {
+    @Autowired
+    private ExgroupRepository exgroupRepository;
+
+
+    @Transactional
+    public void initDB() {
+        initExgroup();
+    }
+
+    private void initExgroup() {
+        Exgroup exgroup1 = createExgroup();
+        Exgroup exgroup2 = createExgroup();
+        exgroupRepository.saveAll(List.of(exgroup1, exgroup2));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- close #93 

## 작업사항
- 운동 그룹 ControllerAcvice, 통합 테스트 작성

## 변경로직
- ExgroupController API 메소드명 변경 (create, read)
- 에러 핸들러 추가
