### PR TITLE
[Feature] 그룹 시작시간에 미션 할당 기능 구현

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -39,12 +39,28 @@ jobs:
           echo "${{ secrets.APPLICATION_JWT_YML }}" > ./application-jwt.yml
         shell: bash
 
-      ## (3) application-oauth.yml 생성
+      ## (3-3) application-oauth.yml 생성
       - name: make application-oauth.yml
         run: |
           cd ./src/main/resources
           touch ./application-oauth.yml
           echo "${{ secrets.APPLICATION_OAUTH_YML }}" > ./application-oauth.yml
+        shell: bash
+
+      ## (3-4) application-fcm.yml 생성
+      - name: make application-fcm.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application-fcm.yml
+          echo "${{ secrets.APPLICATION_FCM_YML }}" > ./application-fcm.yml
+        shell: bash
+
+      ## (3-4) snackpot-fcm.json 생성
+      - name: make snackpot-fcm.json
+        run: |
+          cd ./src/main/resources
+          touch ./snackpot-fcm.json
+          echo "${{ secrets.FCM_JSON_SECRET }}" > ./snackpot-fcm.json
         shell: bash
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ application-dev.yml
 application-prod.yml
 application-oauth.yml
 application-jwt.yml
+application-fcm.yml
+
+### Firebase Cloud Messaging ###
+/src/main/resources/snackpot-fcm.json

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev-api.snackexercise.com")})
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/soma/snackexercise/config/ScheduledConfig.java
+++ b/src/main/java/com/soma/snackexercise/config/ScheduledConfig.java
@@ -1,0 +1,18 @@
+package com.soma.snackexercise.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class ScheduledConfig {
+    private static final int POOL_SIZE = 10; // 한 번에 처리할 건 수
+
+    public TaskScheduler scheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        return scheduler;
+    }
+}

--- a/src/main/java/com/soma/snackexercise/controller/exercise/ExerciseController.java
+++ b/src/main/java/com/soma/snackexercise/controller/exercise/ExerciseController.java
@@ -46,10 +46,10 @@ public class ExerciseController {
                 @ApiResponse(responseCode = "404", description = "운동을 찾을 수 없음", content = @Content(schema = @Schema(implementation = Response.class)))
     })
     @Parameter(name = "exerciseId", description = "조회할 운동 ID", required = true, in = ParameterIn.PATH)
-    @GetMapping("/{id}")
+    @GetMapping("/{exerciseId}")
     @ResponseStatus(HttpStatus.OK)
-    public Response read(@PathVariable Long id) {
-        return Response.success(exerciseService.read(id));
+    public Response read(@PathVariable Long exerciseId) {
+        return Response.success(exerciseService.read(exerciseId));
     }
 
     @Operation(summary = "운동 수정",

--- a/src/main/java/com/soma/snackexercise/controller/notification/NotificationController.java
+++ b/src/main/java/com/soma/snackexercise/controller/notification/NotificationController.java
@@ -1,0 +1,35 @@
+package com.soma.snackexercise.controller.notification;
+
+import com.soma.snackexercise.dto.member.request.MemberUpdateFcmTokenRequest;
+import com.soma.snackexercise.dto.mission.response.TodayMissionResultResponse;
+import com.soma.snackexercise.service.notification.NotificationService;
+import com.soma.snackexercise.util.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Notification", description = "알림 API")
+@RequiredArgsConstructor
+@RestController()
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @Operation(summary = "fcm 토큰 저장", description = "한 명의 회원에 대해 fcm 토큰을 저장합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "fcm 토큰 저장 성공", content = @Content(schema = @Schema(implementation = TodayMissionResultResponse.class))),
+            })
+    @PatchMapping("/members/notification")
+    public Response updateFcmToken(@RequestBody MemberUpdateFcmTokenRequest request, @AuthenticationPrincipal UserDetails loginUser){
+        return Response.success(notificationService.updateFcmToken(request, loginUser.getUsername()));
+    }
+}

--- a/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
+++ b/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
@@ -33,6 +33,9 @@ public class JoinList extends BaseEntity {
     public void addOneOutCount() {
         this.outCount += 1;
     }
+    public void addOneExecutedMissionCountCount() {
+        this.executedMissionCount += 1;
+    }
 
     public void promoteToHost() {
         this.joinType = JoinType.HOST;

--- a/src/main/java/com/soma/snackexercise/domain/member/Member.java
+++ b/src/main/java/com/soma/snackexercise/domain/member/Member.java
@@ -45,6 +45,10 @@ public class Member extends BaseEntity {
         this.name = request.getName();
     }
 
+    public void updateFcmToken(String fcmToken){
+        this.fcmToken = fcmToken;
+    }
+
 
     public void signupMemberInfo(String name, Gender gender, Integer birthYear) {
         this.name = name;

--- a/src/main/java/com/soma/snackexercise/domain/member/Member.java
+++ b/src/main/java/com/soma/snackexercise/domain/member/Member.java
@@ -49,6 +49,10 @@ public class Member extends BaseEntity {
         this.fcmToken = fcmToken;
     }
 
+    public void deleteFcmToken(){
+        this.fcmToken = null;
+    }
+
 
     public void signupMemberInfo(String name, Gender gender, Integer birthYear) {
         this.name = name;

--- a/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
+++ b/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
@@ -41,7 +41,7 @@ public class Mission extends BaseEntity {
 
 
     @Builder
-    public Mission(Exercise exercise, Member member, Exgroup exgroup, Integer alarmCount) {
+    public Mission(Exercise exercise, Member member, Exgroup exgroup) {
         this.exercise = exercise;
         this.member = member;
         this.exgroup = exgroup;

--- a/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
@@ -1,0 +1,13 @@
+package com.soma.snackexercise.domain.notification;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationMessage {
+    ALLOCATE("운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥");
+
+    private final String title;
+    private final String body;
+}

--- a/src/main/java/com/soma/snackexercise/dto/member/request/MemberUpdateFcmTokenRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/member/request/MemberUpdateFcmTokenRequest.java
@@ -1,0 +1,12 @@
+package com.soma.snackexercise.dto.member.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateFcmTokenRequest {
+    private String fcmToken;
+}

--- a/src/main/java/com/soma/snackexercise/dto/member/response/MemberUpdateFcmTokenResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/member/response/MemberUpdateFcmTokenResponse.java
@@ -1,0 +1,19 @@
+package com.soma.snackexercise.dto.member.response;
+
+import com.soma.snackexercise.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateFcmTokenResponse {
+    private Long id;
+    private String nickname;
+    private String fcmToken;
+
+    public static MemberUpdateFcmTokenResponse toDto(Member member) {
+        return new MemberUpdateFcmTokenResponse(member.getId(), member.getNickname(), member.getFcmToken());
+    }
+}

--- a/src/main/java/com/soma/snackexercise/repository/exgroup/ExgroupRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/exgroup/ExgroupRepository.java
@@ -4,10 +4,13 @@ import com.soma.snackexercise.domain.exgroup.Exgroup;
 import com.soma.snackexercise.util.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ExgroupRepository extends JpaRepository<Exgroup, Long> {
     Boolean existsByCode(String code);
 
     Optional<Exgroup> findByIdAndStatus(Long id, Status status);
+
+    List<Exgroup> findAllByStatus(Status status);
 }

--- a/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JoinListRepository extends JpaRepository<JoinList, Long> {
@@ -25,4 +26,13 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long> {
 
     @Query("SELECT count(*) FROM JoinList j WHERE j.exgroup = :exgroup AND j.outCount <= 1 AND j.status = 'ACTIVE'")
     Integer countByExgroupAndOutCountLessThanOneAndStatusEqualsActive(@Param("exgroup") Exgroup exgroup);
+
+    List<JoinList> findByExgroupAndStatus(Exgroup exgroup, Status status);
+
+    // 미션 수행 횟수 가장 적은 그룹원들
+    @Query("SELECT m FROM JoinList j " +
+            "   JOIN j.member m" +
+            "   WHERE j.exgroup = :exgroup AND j.status = 'ACTIVE'" +
+            "         AND j.executedMissionCount = (SELECT MIN(j2.executedMissionCount) FROM JoinList j2 WHERE j2.exgroup =: exgroup)")
+    List<Member> findMinExecutedMemberList(@Param("exgroup") Exgroup exgroup);
 }

--- a/src/main/java/com/soma/snackexercise/repository/mission/MissionRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/mission/MissionRepository.java
@@ -13,23 +13,49 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     void deleteByMember(Member member);
 
+    /**
+     * 그룹원들 중에서 특정 기간 동안 미션을 가장 많이 수행한 사람의 미션수행완료횟수를 반환합니다.
+     * @param exgroupId 그룹 ID
+     * @param startDateTime 시작 일자
+     * @param endDateTime 종료 일자
+     * @return 특정 기간 동안, 그룹 내 최대 미션수행완료 횟수
+     */
     @Query("SELECT count(*) AS cnt" +
             "    FROM Mission m" +
-            "    WHERE m.exgroup.id = :exgroupId AND :today <= m.createdAt AND m.createdAt < :nextday AND m.endAt IS NOT NULL" +
+            "    WHERE m.exgroup.id = :exgroupId AND :startDateTime <= m.createdAt AND m.createdAt < :endDateTime AND m.endAt IS NOT NULL" +
             "    GROUP BY m.member" +
             "    ORDER BY cnt DESC" +
             "    LIMIT 1")
-    Integer findCurrentFinishedRelayCountByGroupId(@Param("exgroupId") Long exgroupId, @Param("today") LocalDateTime today, @Param("nextday") LocalDateTime nextday);
+    Integer findCurrentFinishedRelayCountByGroupId(@Param("exgroupId") Long exgroupId, @Param("startDateTime") LocalDateTime startDateTime, @Param("endDateTime") LocalDateTime endDateTime);
 
+    /**
+     * 특정 기간 동안 하나의 그룹의 모든 그룹원들에게 할당된 미션 리스트를 반환합니다. (미수행 미션 + 수행 완료 미션 모두 포함)
+     * @param exgroupId 그룹 ID
+     * @param startDateTime 시작 일자
+     * @param endDateTime 종료 일자
+     * @return 특정 기간 동안 하나의 그룹의 모든 그룹원에게 할당된 미션 리스트
+     */
     @Query("SELECT m" +
             "   FROM Mission m JOIN FETCH m.member" +
-            "   WHERE m.exgroup.id = :exgroupId AND :today <= m.createdAt AND m.createdAt < :nextday" +
+            "   WHERE m.exgroup.id = :exgroupId AND :startDateTime <= m.createdAt AND m.createdAt < :endDateTime" +
             "   ORDER BY m.createdAt")
-    List<Mission> findAllMissionByGroupIdAndCreatedAt(@Param("exgroupId") Long exgroupId, @Param("today") LocalDateTime today, @Param("nextday") LocalDateTime nextday);
+    List<Mission> findAllMissionByGroupIdAndCreatedAt(@Param("exgroupId") Long exgroupId, @Param("startDateTime") LocalDateTime startDateTime, @Param("endDateTime") LocalDateTime endDateTime);
 
+
+    /**
+     *  특정 기간 동안 하나의 그룹의 모든 그룹원들이 수행 완료한 미션 리스트를 반환합니다.
+     * @param exgroupId 그룹 ID
+     * @param startDateTime 시작 일자
+     * @param endDateTime 종료 일자
+     * @return 특정 기간 동안 하나의 그룹의 모든 그룹원들이 수행 완료한 미션 리스트
+     */
     @Query("SELECT m" +
             "   FROM Mission m JOIN FETCH m.member" +
-            "   WHERE m.exgroup.id = :exgroupId AND :today <= m.createdAt AND m.createdAt < :nextday AND m.startAt IS NOT NULL" +
+            "   WHERE m.exgroup.id = :exgroupId AND :startDateTime <= m.createdAt AND m.createdAt < :endDateTime AND m.startAt IS NOT NULL" +
             "   ORDER BY m.createdAt")
-    List<Mission> findAllExecutedMissionByGroupIdAndCreatedAt(@Param("exgroupId") Long exgroupId, @Param("today") LocalDateTime today, @Param("nextday") LocalDateTime nextday);
+    List<Mission> findAllExecutedMissionByGroupIdAndCreatedAt(@Param("exgroupId") Long exgroupId, @Param("startDateTime") LocalDateTime startDateTime, @Param("endDateTime") LocalDateTime endDateTime);
+
+
+
+
 }

--- a/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/exgroup/ExgroupService.java
@@ -42,12 +42,12 @@ public class ExgroupService {
 
         // 2. 그룹 코드 생성
         String groupCode = CreateExgroupCode.createGroupCode();
-        Boolean flag = exgroupRepository.existsByCode(groupCode); // 코드 중복 여부
+        Boolean isDuplicatedGroupCode = exgroupRepository.existsByCode(groupCode); // 코드 중복 여부
 
         // 3. 그룹 코드 중복 검사
-        while(Boolean.TRUE.equals(flag)){ // 코드 중복 검사 불통과시 코드 재발급
+        while(Boolean.TRUE.equals(isDuplicatedGroupCode)){ // 코드 중복 검사 불통과시 코드 재발급
             groupCode = CreateExgroupCode.createGroupCode();
-            flag = exgroupRepository.existsByCode(groupCode);
+            isDuplicatedGroupCode = exgroupRepository.existsByCode(groupCode);
         }
 
         log.info("generate group code : {}", groupCode);

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -1,0 +1,80 @@
+package com.soma.snackexercise.service.mission;
+
+import com.soma.snackexercise.domain.exgroup.Exgroup;
+import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.exception.MemberNotFoundException;
+import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
+import com.soma.snackexercise.repository.joinlist.JoinListRepository;
+import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.service.notification.FirebaseCloudMessageService;
+import com.soma.snackexercise.util.constant.Status;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static com.soma.snackexercise.domain.notification.NotificationMessage.ALLOCATE;
+import static java.lang.Math.abs;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MissionSchedulerService {
+    private final ExgroupRepository exgroupRepository;
+    private final MemberRepository memberRepository;
+    private final FirebaseCloudMessageService firebaseCloudMessageService;
+    private final JoinListRepository joinListRepository;
+
+    private static Random random = new Random();
+
+    /**
+     * 5초 마다 현재 시각과 그룹의 시작시각 차이가 5초 이하라면, 그룹원 한 명에게 미션을 할당하고 알림을 보냅니다.
+     */
+    @Scheduled(fixedRate = 5000) // 이전 Task 시작 시점으로부터 5초가 지난 후 Task 실행
+    public void allocateMissionAtGroupStartTime(){
+        List<Exgroup> exgroupList = exgroupRepository.findAllByStatus(Status.ACTIVE);
+        List<String> tokenList = new ArrayList<>();
+
+        // 모든 그룹에 대해서 현재 시각이 그룹의 시작시간과 시간차이가 5초 이하인 그룹에 대해서 미션 할당 및 알림 보내기
+        LocalTime now = LocalTime.now();
+        for (Exgroup exgroup : exgroupList) {
+            long timeDiff = abs(ChronoUnit.SECONDS.between(now, exgroup.getStartTime()));
+
+            // 그룹 시작시각과 현재시각의 차이가 5이상이라면, 알림을 보내지 않음
+            if(timeDiff >= 5){
+                return;
+            }
+            Member targetMember = getMissionAllocatedMember(exgroup);
+            tokenList.add(targetMember.getFcmToken());
+
+            log.info("그룹명 : {}, 그룹원 : {}, 할당 시각 : {}", exgroup.getName(), targetMember.getName(), LocalDateTime.now());
+        }
+
+        // tokenList로 알림 보내기
+        firebaseCloudMessageService.sendByTokenList(tokenList, ALLOCATE.getTitle(), ALLOCATE.getBody());
+    }
+
+    /**
+     * 특정 그룹에서 운동 미션을 할당할 회원을 선정하여 반환합니다.
+     * @param exgroup 그룹
+     * @return 운동 미션이 할당된 회원
+     */
+    Member getMissionAllocatedMember(Exgroup exgroup){
+        Member targetMember;
+        if(exgroup.getCurrentDoingMemberId() != null){// 1. 현재 수행중인 멤버가 있다면, 해당 멤버에게 미션 알림 보내기
+            targetMember = memberRepository.findByIdAndStatus(exgroup.getCurrentDoingMemberId(), Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+        }else{// 2. 현재 수행중인 멤버가 없다면(처음 할당), 그룹 내 미션 수행 횟수가 가장 적은 사람 중에서 랜덤한 멤버에게 미션 할당 및 알림 보내기
+            List<Member> minExecutedMemberList = joinListRepository.findMinExecutedMemberList(exgroup);
+            int randomIndex = random.nextInt(minExecutedMemberList.size());
+            targetMember = minExecutedMemberList.get(randomIndex);
+        }
+        return targetMember;
+    }
+}

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -1,11 +1,15 @@
 package com.soma.snackexercise.service.mission;
 
+import com.soma.snackexercise.domain.exercise.Exercise;
 import com.soma.snackexercise.domain.exgroup.Exgroup;
 import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.domain.mission.Mission;
 import com.soma.snackexercise.exception.MemberNotFoundException;
+import com.soma.snackexercise.repository.exercise.ExerciseRepository;
 import com.soma.snackexercise.repository.exgroup.ExgroupRepository;
 import com.soma.snackexercise.repository.joinlist.JoinListRepository;
 import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.repository.mission.MissionRepository;
 import com.soma.snackexercise.service.notification.FirebaseCloudMessageService;
 import com.soma.snackexercise.util.constant.Status;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,8 @@ public class MissionSchedulerService {
     private final MemberRepository memberRepository;
     private final FirebaseCloudMessageService firebaseCloudMessageService;
     private final JoinListRepository joinListRepository;
+    private final ExerciseRepository exerciseRepository;
+    private final MissionRepository missionRepository;
 
     private static Random random = new Random();
 
@@ -54,6 +60,12 @@ public class MissionSchedulerService {
             Member targetMember = getMissionAllocatedMember(exgroup);
             tokenList.add(targetMember.getFcmToken());
 
+            missionRepository.save(Mission.builder()
+                    .exercise(getRandomExercise())
+                    .member(targetMember)
+                    .exgroup(exgroup)
+                    .build());
+
             log.info("그룹명 : {}, 그룹원 : {}, 할당 시각 : {}", exgroup.getName(), targetMember.getName(), LocalDateTime.now());
         }
 
@@ -76,5 +88,15 @@ public class MissionSchedulerService {
             targetMember = minExecutedMemberList.get(randomIndex);
         }
         return targetMember;
+    }
+
+    /**
+     *
+     * @return 랜덤한 운동 1개를 반환합니다.
+     */
+    Exercise getRandomExercise(){
+        List<Exercise> exerciseList = exerciseRepository.findAll();
+        int randomIndex = random.nextInt(exerciseList.size());
+        return exerciseList.get(randomIndex);
     }
 }

--- a/src/main/java/com/soma/snackexercise/service/notification/FirebaseCloudMessageService.java
+++ b/src/main/java/com/soma/snackexercise/service/notification/FirebaseCloudMessageService.java
@@ -1,0 +1,111 @@
+package com.soma.snackexercise.service.notification;
+
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class FirebaseCloudMessageService {
+
+    @Value("${fcm.key.path}")
+    private String FCM_PRIVATE_KEY_PATH;
+
+
+    // 메시징만 권한 설정
+    @Value("${fcm.key.scope}")
+    private String fireBaseScope;
+
+    // fcm 기본 설정 진행
+    @PostConstruct
+    public void init() {
+        try {
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(
+                            GoogleCredentials
+                                    .fromStream(new ClassPathResource(FCM_PRIVATE_KEY_PATH).getInputStream())
+                                    .createScoped(List.of(fireBaseScope)))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase application has been initialized");
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            // spring 뜰때 알림 서버가 잘 동작하지 않는 것이므로 바로 죽임
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+
+    /**
+     * tokenList를 받아 여러 개의 기기로 알림 보내기
+     * @param tokenList 알림 보낼 fcmToken 리스트
+     * @param title 알림 메세지 제목
+     * @param body 알림 메세지 본문
+     */
+    public void sendByTokenList(List<String> tokenList, String title, String body) {
+
+        //여러기기에 메세지 전송
+        MulticastMessage multicastMessage = MulticastMessage.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .addAllTokens(tokenList)
+                .build();
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(multicastMessage);
+            if (response.getFailureCount() > 0) {
+                List<SendResponse> responses = response.getResponses();
+                List<String> failedTokens = new ArrayList<>();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        failedTokens.add(tokenList.get(i));
+                    }
+                }
+                log.info("List of tokens that caused failures: {}", failedTokens);
+            }
+        } catch (FirebaseMessagingException e) {
+            log.info("FirebaseMessagingException: {}", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 하나의 token을 받아서, 한개의 기기로 알림 보내기
+     * @param token 알림 보낼 fcmToken
+     * @param title 알림 메세지 제목
+     * @param body 알림 메세지 본문
+     */
+    public void sendByToken(String token, String title, String body) {
+
+        // 메세지 만들기
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            log.info("FirebaseMessagingException: {}, fail token: {}", e.getMessage(), token);
+        }
+    }
+}

--- a/src/main/java/com/soma/snackexercise/service/notification/NotificationService.java
+++ b/src/main/java/com/soma/snackexercise/service/notification/NotificationService.java
@@ -1,0 +1,25 @@
+package com.soma.snackexercise.service.notification;
+
+import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.dto.member.request.MemberUpdateFcmTokenRequest;
+import com.soma.snackexercise.dto.member.response.MemberUpdateFcmTokenResponse;
+import com.soma.snackexercise.exception.MemberNotFoundException;
+import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.util.constant.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public MemberUpdateFcmTokenResponse updateFcmToken(MemberUpdateFcmTokenRequest request, String email){
+        Member member = memberRepository.findByEmailAndStatus(email, Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+        member.updateFcmToken(request.getFcmToken());
+        return MemberUpdateFcmTokenResponse.toDto(member);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,3 +27,7 @@ spring:
     init:
       mode: always
 
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,4 @@ spring:
     include:
       - jwt
       - oauth
+      - fcm

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,9 +8,9 @@ INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email,
 INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email, fcmToken, status, createdAt, updatedAt, birthYear) VALUES (7, '박보검', null, 'park', 'MALE', 'KAKAO', 'park@gmail.com', null, 'ACTIVE', '2023-07-21 14:53:29', '2023-07-21 14:53:29', '1993');
 
 -- INSERT EXGROUP
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '운동하자', '', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '운동하자', '🍉', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
 ', '105236', '2023-07-21 23:55:26', '2023-07-21 23:55:26', null, 10, 2, NULL, NULL, 14, 14, 'ACTIVE');
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (3, '짧고굵게', '', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (3, '짧고굵게', '☘️', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
 ', '꼴등 스쿼트 50개 영상찍어 올리기', '156398', '2023-07-21 23:58:14', '2023-07-21 23:55:26', null, 10, 3, NULL, NULL, 14, 8, 'ACTIVE');
 
 -- INSERT JOINLIST


### PR DESCRIPTION
## 관련 이슈 번호
- close #49

## 작업사항
- 푸시 알림 기능을 위해 FCM 연동
- 그룹 시작 시간에 미션 할당 기능 추가

## 변경로직
- fcmToken 연동 코드 작성
- fcm 알림 전송 요청 서비스 로직 작성
- fcm token 저장 로직 작성
- 로그아웃시 fcmToken 삭제 로직 작성
- 스케줄러를 사용하여 5초 단위로 그룹의 시작시간 여부 검사 및 미션할당 및 알림 기능 추가