### PR TITLE
[Feature] 운동 미션 수행 완료 API

### DIFF
--- a/src/main/java/com/soma/snackexercise/domain/group/Group.java
+++ b/src/main/java/com/soma/snackexercise/domain/group/Group.java
@@ -10,6 +10,8 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static java.lang.Boolean.*;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -42,6 +44,8 @@ public class Group extends BaseEntity {
 
     private LocalDate endDate; // 종료 기간
 
+    private Boolean isGoalAchieved; // 성공 여부
+
     private String penalty; // 벌칙
 
     private String code; // 그룹 입장 코드
@@ -58,6 +62,10 @@ public class Group extends BaseEntity {
         }
 
         this.maxMemberNum = newMaxMemberNum;
+    }
+
+    public void updateCurrentDoingMemberId(Long memberId){
+        this.currentDoingMemberId = memberId;
     }
 
     public void update(GroupUpdateRequest request) {
@@ -78,6 +86,10 @@ public class Group extends BaseEntity {
         this.endDate = startDate.plusDays(existDays);
     }
 
+    public void updateIsGoalAchieved(){
+        this.isGoalAchieved = TRUE;
+    }
+
     @Builder
     public Group(String name, String emozi, String color, String description,
                  Integer maxMemberNum, Integer goalRelayNum, LocalTime startTime,
@@ -96,6 +108,7 @@ public class Group extends BaseEntity {
         this.code = code;
         this.checkIntervalTime = checkIntervalTime;
         this.checkMaxNum = checkMaxNum;
+        this.isGoalAchieved = FALSE;
         active();
     }
 

--- a/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
+++ b/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
@@ -33,7 +33,8 @@ public class JoinList extends BaseEntity {
     public void addOneOutCount() {
         this.outCount += 1;
     }
-    public void addOneExecutedMissionCountCount() {
+
+    public void addOneExecutedMissionCount() {
         this.executedMissionCount += 1;
     }
 

--- a/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
+++ b/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
@@ -50,15 +50,27 @@ public class Mission extends BaseTimeEntity {
         this.alarmCount = 0;
     }
 
+    /**
+     * 미션 시작 버튼 클릭시, 미션 시작 시간 기록
+     */
     public void startMission(){
         this.startAt = LocalDateTime.now();
     }
 
-    public void endMission(Integer calory){
-        this.endAt = LocalDateTime.now();
+    /**
+     * 운동 종료시, 소모 칼로리와 운동 종료 시각을 기록
+     * @param calory 소모 칼로리
+     * @param lengthOfVideo 운동 영상 길이
+     */
+    public void endMission(Integer calory, Long lengthOfVideo){
+        this.endAt = this.startAt.plusMinutes(lengthOfVideo);
         this.calory = calory;
     }
 
+    /**
+     * 운동 할당 시각과 운동 시각 사이의 시각 차이를 계산
+     * @return 운동 할당 시각과 운동 시작 시각의 시간 차이
+     */
     public Long calculateMinutesDiffBetweenCreateAndStart() {
         if(getStartAt() == null || getCreatedAt() == null){
             throw new CalculateMinutesDiffException();

--- a/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationMessage {
-    ALLOCATE("운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥");
+    ALLOCATE("운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥"),
+    GROUP_GOAL_ACHIEVE("그룹 목표 달성! 🙌", "그룹의 목표 릴레이 횟수를 모두 달성했어요! 👍🏻");
 
     private final String title;
     private final String body;

--- a/src/main/java/com/soma/snackexercise/dto/mission/request/MissionFinishRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/request/MissionFinishRequest.java
@@ -1,0 +1,13 @@
+package com.soma.snackexercise.dto.mission.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MissionFinishRequest {
+    private Integer calory; // 소모 칼로리
+    private Long lengthOfVideo; // 영상길이
+}

--- a/src/main/java/com/soma/snackexercise/dto/mission/response/MissionFinishResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/MissionFinishResponse.java
@@ -1,0 +1,10 @@
+package com.soma.snackexercise.dto.mission.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MissionFinishResponse {
+    private Boolean isGroupGoalAchieved; // 그룹 목표 달성 여부
+}

--- a/src/main/java/com/soma/snackexercise/exception/FcmTokenEmptyException.java
+++ b/src/main/java/com/soma/snackexercise/exception/FcmTokenEmptyException.java
@@ -1,0 +1,4 @@
+package com.soma.snackexercise.exception;
+
+public class FcmTokenEmptyException extends RuntimeException{
+}

--- a/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
@@ -125,4 +125,20 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long> {
             "WHERE j.group = :group " +
             "AND j.status = :status )")
     Integer findCurrentRoundPositionByGroupId(@Param("group") Group group, @Param("status") Status status);
+
+    /**
+     * 그룹에서 목표 릴레이 횟수를 달성한 회원의 수를 반환합니다.
+     * @param group 그룹
+     * @return 그룹에서 목표 릴레이 횟수를 달성한 회원의 수
+     */
+    @Query("SELECT count(*) FROM JoinList j WHERE j.group = :group AND j.executedMissionCount = j.group.goalRelayNum AND j.status = 'ACTIVE'")
+    Integer countGroupGoalAchievedMember(@Param("group") Group group);
+
+    /**
+     * 그룹의 회원 수를 반환합니다.
+     * @param group 그룹
+     * @return 그룹의 회원 수
+     */
+    @Query("SELECT count(*) FROM JoinList j WHERE j.group = :group AND j.status = 'ACTIVE'")
+    Integer countGroupMember(@Param("group") Group group);
 }

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionUtil.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionUtil.java
@@ -1,0 +1,61 @@
+package com.soma.snackexercise.service.mission;
+
+import com.soma.snackexercise.domain.exercise.Exercise;
+import com.soma.snackexercise.domain.group.Group;
+import com.soma.snackexercise.domain.member.Member;
+import com.soma.snackexercise.exception.MemberNotFoundException;
+import com.soma.snackexercise.repository.exercise.ExerciseRepository;
+import com.soma.snackexercise.repository.joinlist.JoinListRepository;
+import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.util.constant.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Component // TODO @Service? @Component?
+public class MissionUtil {
+    private final MemberRepository memberRepository;
+    private final JoinListRepository joinListRepository;
+    private final ExerciseRepository exerciseRepository;
+
+    private static Random random = new Random();
+
+    /**
+     * 그룹의 시작시간에 알림이 전송될 회원을 반환합니다.
+     * @param group 그룹
+     * @return 그룹의 시작 시간에 알림이 전송될 회원
+     */
+    Member getMissionAllocatedMember(Group group){
+        Member targetMember;
+        if(group.getCurrentDoingMemberId() != null){// 1. 현재 수행중인 멤버가 있다면, 해당 멤버에게 미션 알림 보내기
+            targetMember = memberRepository.findByIdAndStatus(group.getCurrentDoingMemberId(), Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
+        }else{// 2. 현재 수행중인 멤버가 없다면(처음 할당), 그룹 내 미션 수행 횟수가 가장 적은 사람 중에서 랜덤한 멤버에게 미션 할당 및 알림 보내기
+            targetMember = getNextMissionMember(group);
+        }
+        return targetMember;
+    }
+
+    /**
+     *
+     * @return 랜덤한 운동 1개를 반환합니다.
+     */
+    Exercise getRandomExercise(){
+        List<Exercise> exerciseList = exerciseRepository.findAll();
+        int randomIndex = random.nextInt(exerciseList.size());
+        return exerciseList.get(randomIndex);
+    }
+
+    /**
+     * 그룹 내에서 미션을 할당할 회원을 선정합니다.
+     * @param group 그룹
+     * @return 미션을 할당받을 회원
+     */
+    Member getNextMissionMember(Group group){
+        List<Member> minExecutedMemberList = joinListRepository.findMinExecutedMemberList(group);
+        int randomIndex = random.nextInt(minExecutedMemberList.size());
+        return minExecutedMemberList.get(randomIndex);
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -11,20 +11,22 @@ INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email,
 INSERT INTO Member (id, name, profileImage, nickname, gender, socialType, email, fcmToken, status, createdAt, updatedAt, birthYear) VALUES (7, '박보검', null, 'park', 'MALE', 'KAKAO', 'park@gmail.com', null, 'ACTIVE', now(), now(), '1993');
 
 -- INSERT EXGROUP
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (1, '운동하자', '🍉', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
-', '105236', now(), now(), null, 10, 2, NULL, NULL, 14, 14, 'ACTIVE');
-INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, goalRelayNum, existDays, status) VALUES (2, '짧고굵게', '☘️', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
-', '꼴등 스쿼트 50개 영상찍어 올리기', '156398', now(), now(), null, 10, 3, NULL, NULL, 14, 8, 'ACTIVE');
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, isGoalAchieved ,goalRelayNum, existDays, status) VALUES (1, '운동하자', '🍉', '#101010', 6, '09:00:00', '18:00:00', '저희 그룹은 2주동안 매일매일 운동하는 것을 목표로합니다.', '꼴등이 1등한테 스벅 깊티 쏘기
+', '105236', now(), now(), null, 10, 2, NULL, NULL, FALSE, 14, 14, 'ACTIVE');
+INSERT INTO Exgroup (id, name, emozi, color, maxMemberNum, startTime, endTime, description, penalty, code, createdAt, updatedAt, currentDoingMemberId, checkIntervalTime, checkMaxNum, startDate, endDate, isGoalAchieved, goalRelayNum, existDays, status) VALUES (2, '짧고굵게', '☘️', '#638391', 4, '10:00:00', '16:00:00', '짧고 굵게 딱 1주일 동안 운동하자!
+', '꼴등 스쿼트 50개 영상찍어 올리기', '156398', now(), now(), null, 10, 3, NULL, NULL, FALSE, 14, 8, 'ACTIVE');
 
 -- INSERT JOINLIST
-INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (1, 1, 1, now(), 'HOST', now(), 0, 'ACTIVE', 0);
-INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (2, 1, 2, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
-INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (3, 2, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
+-- 1번 그룹 : 1, 2, 3, 5, 6, 7
+INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (1, 1, 1, now(), 'HOST', now(), 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (3, 2, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 0);
 INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (4, 3, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
-INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (5, 4, 2, now(), 'HOST', now(), 0, 'ACTIVE', 0);
 INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (6, 5, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
-INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (7, 6, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 0);
+INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (7, 6, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
 INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (8, 7, 1, now(), 'MEMBER', now(), 0, 'ACTIVE', 0);
+-- 2번 그룹 : 1, 4
+INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (2, 1, 2, now(), 'MEMBER', now(), 0, 'ACTIVE', 1);
+INSERT INTO JoinList (id, memberId, groupId, createdAt, joinType, updatedAt, outCount, status, executedMissionCount) VALUES (5, 4, 2, now(), 'HOST', now(), 0, 'ACTIVE', 0);
 
 -- INSERT EXERCISE
 INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, now(), 1, now(), '어디서나 할 수 있는 전신 운동 입니다
@@ -40,6 +42,8 @@ INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exercis
 INSERT INTO Exercise (minPerKcal, createdAt, id, updatedAt, description, exerciseCategory, name, status, videoLink) VALUES (10, now(), 5, now(), '복근 운동', 'EXERCISE', '복근 운동', 'ACTIVE', 'https://www.youtube.com/shorts/1K0Ono8vo1o');
 
 -- INSERT MISSION
+-- 1번 그룹 : 1, 3, 5, 6 수행 완료, 2번 현재 수행 차례
+-- 2번 그룹 : 1번 현재 수행 차례
 INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, groupId, id, memberId, startAt, updatedAt) VALUES (0, 10, now(), TIMESTAMPADD(MINUTE, 15, now()), 1, 1, 1, 1, TIMESTAMPADD(MINUTE, 10, now()), now());
 INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, groupId, id, memberId, startAt, updatedAt) VALUES (0, 15, TIMESTAMPADD(MINUTE, 15, now()), TIMESTAMPADD(MINUTE, 45, now()), 3, 1, 2, 3, TIMESTAMPADD(MINUTE, 43, now()), TIMESTAMPADD(MINUTE, 15, now()));
 INSERT INTO Mission (alarmCount, calory, createdAt, endAt, exerciseId, groupId, id, memberId, startAt, updatedAt) VALUES (2, 25, TIMESTAMPADD(MINUTE, 45, now()), TIMESTAMPADD(MINUTE, 60, now()), 4, 1, 3, 5, TIMESTAMPADD(MINUTE, 53, now()), TIMESTAMPADD(MINUTE, 45, now()));

--- a/src/test/java/com/soma/snackexercise/factory/entity/MissionFactory.java
+++ b/src/test/java/com/soma/snackexercise/factory/entity/MissionFactory.java
@@ -22,7 +22,7 @@ public class MissionFactory {
                 .build();
 
         mission.startMission();
-        mission.endMission(3);
+        mission.endMission(3, 10L);
 
         return mission;
     }

--- a/src/test/java/com/soma/snackexercise/repository/joinlist/JoinListRepositoryTest.java
+++ b/src/test/java/com/soma/snackexercise/repository/joinlist/JoinListRepositoryTest.java
@@ -169,14 +169,14 @@ class JoinListRepositoryTest {
     @Test
     void findMaxExecutedMissionCountByGroupAndStatusTest() {
         joinList = joinListRepository.save(createJoinListForMember(member, group));
-        joinList.addOneExecutedMissionCountCount();
-        joinList.addOneExecutedMissionCountCount();
+        joinList.addOneExecutedMissionCount();
+        joinList.addOneExecutedMissionCount();
         joinListRepository.save(joinList);
 
         Member member1 = memberRepository.save(createMember());
         JoinList joinList1 = joinListRepository.save(createJoinListForMember(member1, group));
-        joinList1.addOneExecutedMissionCountCount();
-        joinList1.addOneExecutedMissionCountCount();
+        joinList1.addOneExecutedMissionCount();
+        joinList1.addOneExecutedMissionCount();
         joinListRepository.save(joinList1);
 
         clear();


### PR DESCRIPTION
## 관련 이슈 번호
- close #112

## 작업사항
- 운동 미션 수행 완료 API 작성

## 변경로직
- Exgroup 엔티티에 그룹 목표 달성 여부 컬럼을 추가하였습니다.
- 운동 종료시, 시간 기록 로직을 종료한 현재 시각을 기록하는 기존 방식에서, 시작시간 + 영상의 길이를 종료시간으로 기록하도록 수정하였습니다.
- MissionService, MissionSchedulerService에서 공통으로 사용하는 함수는 MissionUtil 클래스로 분리하였습니다.
- 미션 수행 완료 API를 작성하였습니다.
