### PR TITLE
[Fix] 

### DIFF
--- a/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
+++ b/src/main/java/com/soma/snackexercise/dto/mission/response/MemberMissionDto.java
@@ -20,8 +20,8 @@ public class MemberMissionDto {
                 mission.getMember().getId(),
                 mission.getMember().getNickname(),
                 mission.getMember().getProfileImage(),
-                mission.getStartAt(),
-                mission.getEndAt()
+                mission.getCreatedAt(), // 할당 시각
+                mission.getEndAt() // 종료 시각
         );
     }
 }

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -63,7 +63,7 @@ public class MissionService {
         Integer currentFinishedRelayCount = missionRepository.findCurrentFinishedRelayCountByGroupId(groupId, todayMidnight, tomorrowMidnight);
 
         // 3. 모든 그룹원의 오늘 수행한 미션 현황
-        List<Mission> missions = missionRepository.findMissionsByGroupIdWithinDateRange(groupId, todayMidnight, tomorrowMidnight);
+        List<Mission> missions = missionRepository.findFinishedMissionsByGroupIdWithinDateRange(groupId, todayMidnight, tomorrowMidnight);
         List<MemberMissionDto> missionFlow = missions.stream().map(MemberMissionDto::toDto).toList();
 
         return new TodayMissionResultResponse(missionFlow, currentFinishedRelayCount, group.getEndDate());
@@ -149,6 +149,7 @@ public class MissionService {
     public MissionStartResponse missionStart(MissionStartRequest request) {
         Mission mission = missionRepository.findById(request.getMissionId()).orElseThrow(MissionNotFoundException::new);
         mission.startMission();
+        log.info("[미션 시작 시각] {}", mission.getStartAt());
         return MissionStartResponse.toDto(mission);
     }
 


### PR DESCRIPTION
## 작업사항
- 당일 미션 수행 현황 조회 API 수정

## 변경로직
- response DTO를 시작시간(startAt)에서 할당시각(createdAt)으로 수정
- repository의 수행하지 않은 모든 미션까지 가져오는 함수에서 수행 완료한 미션만 가져오는 함수로 수정
