### PR TITLE
[Fix]  스프링부트 애플리케이션 TimeZone 설정, 스케줄러 주기 조정

### DIFF
--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -2,16 +2,28 @@ package com.soma.snackexercise;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import javax.annotation.PostConstruct;
+import java.util.Date;
+import java.util.TimeZone;
+
+@Slf4j
 @EnableScheduling
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev-api.snackexercise.com")})
 @EnableJpaAuditing
 @SpringBootApplication
 public class SnackExerciseApplication {
+
+    @PostConstruct
+    public void started(){
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        log.info("현재시각 : " + new Date());
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SnackExerciseApplication.class, args);

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -47,8 +47,10 @@ public class MissionSchedulerService {
      * 5초 마다 현재 시각과 그룹의 시작시각 차이가 5초 이하라면, 그룹원 한 명에게 미션을 할당하고 알림을 보냅니다.
      */
     // todo : Transactionl을 붙여주는게 나을까..?
-    @Scheduled(fixedRate = 5000) // 이전 Task 시작 시점으로부터 5초가 지난 후 Task 실행
+    //@Scheduled(fixedRate = 5000) // 이전 Task 시작 시점으로부터 5초가 지난 후 Task 실행
+    @Scheduled(cron = "1 * * * * *") // 1분마다 실행, cron 표현식
     public void allocateMissionAtGroupStartTime() {
+        log.info("============= 그룹 시작 시간 미션 할당 스케줄러 =============");
         // 종료 여부가 false인 group에 대해서
         List<Group> groupList = groupRepository.findAllByIsGoalAchievedAndStatus(false, Status.ACTIVE);
         List<String> tokenList = new ArrayList<>();
@@ -81,8 +83,10 @@ public class MissionSchedulerService {
         }
     }
 
-    @Scheduled(fixedRate = 5000)
+    //@Scheduled(fixedRate = 5000)
+    @Scheduled(cron = "0 * * * * *") // 1분마다 실행, cron 표현식
     public void sendReminderNotifications() {
+        log.info("============= 자동 독촉 알람 스케줄러 =============");
         // 종료 여부가 false인 그룹에 대해서
         List<Group> groupList = groupRepository.findAllByIsGoalAchievedAndStatus(false, Status.ACTIVE);
 
@@ -121,8 +125,10 @@ public class MissionSchedulerService {
     }
 
     @Transactional
-    @Scheduled(fixedRate = 5000)
+    //@Scheduled(fixedRate = 5000
+    @Scheduled(cron = "0 0 0/1 * * *") // 1시간마다 실행, cron 표현식
     public void inActiveGroupsPastEndDate() {
+        log.info("============= 그룹 종료 일자 스케줄러 =============");
         // 종료 여부에 관계없이 group이 Active한 그룹들 중에서 EndDate가 지난 그룹
         LocalDate now = LocalDate.now();
         List<Group> groupList = groupRepository.findAllByEndDateGreaterThanAndStatus(now, Status.ACTIVE);


### PR DESCRIPTION
## 작업사항
- 스프링부트 애플리케이션 TimeZone 설정
- 스케줄러 주기 조정

## 변경로직
- 스프링부트 애플리케이션 TimeZone 설정
     - 스프링부트는 실행되는 서버 환경의 TimeZone을 따라간다. 현재 docker exec spring-dev date로 확인해보니 docker의 기본 시간대가 UTC로 설정되어있었다. 따라서 @PostConstruct로 timezone을 설정했다. 
     - 그러나 타임존 설정을 위한 코드가 프로덕션 코드에 포함되기에, 추후에 docker compose에 environment를 사용하여 timezone을 설정하도록 수정하는 것을 고려해볼 수 있다.

- 스케줄러 주기 조정
    - 그룹 시작 시간에 미션 할당 스케줄링 기능과, 미션 할당 시각 기준으로 일정 시각 이내에 미션을 수행하지 않을 경우 알람을 보내주는 스케줄링 기능의 경우, 최소 설정 시간 단위가 분이므로 1분 마다 스케줄러가 실행되도록 하였다.
    - 그룹의 종료일자가 지났을 경우 Group, JoinList의 Status를 Inactive로 수정하는 작업은 1분마다 실행할 정도로 중요한 작업은 아니라고 생각하여 1시간 마다 실행되도록 주기를 수정하였다.
