### PR TITLE
[Fix] 스케줄러 시간 단위 수정

### DIFF
--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_GROUP_CODE_EXCEPTION(-1203, "잘못된 그룹 코드 입니다."),
     ALREADY_JOINED_GROUP_EXCEPTION(-1204, "이미 해당 운동 그룹에 가입되어 있습니다."),
     EXCEEDS_KICK_OUT_LIMIT_EXCEPTION(-1205, "그룹에 다시 가입할 수 없습니다."),
+    NOT_STARTED_GROUP(-1206, "그룹이 아직 시작하지 않았습니다."),
 
     /* JoinList */
     JOIN_LIST_NOT_FOUND_EXCEPTION(-1300, "회원_운동그룹이 존재하지 않습니다."),

--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
     /* Mission */
     MISSION_NOT_FOUND_EXCEPTION(-1400, "미션이 존재하지 않습니다."),
 
+    /* Exercise */
+    EXERCISE_NOT_FOUND_EXCEPTION(-1500, "운동이 존재하지 않습니다."),
+
     /* QueryParam */
     WRONG_QUERY_PARAM_EXCEPTION(-1900, "잘못된 Query Param입니다.");
 

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -102,12 +102,18 @@ public class ExceptionAdvice {
         return Response.failure(MISSION_NOT_FOUND_EXCEPTION);
     }
 
+    @ExceptionHandler(NotStartedGroupException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response notStartedGroupExceptionHandler (NotStartedGroupException e){
+        return Response.failure(NOT_STARTED_GROUP);
+    }
+
     /*
     Exercise
      */
     @ExceptionHandler(ExerciseNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Response exerciseNotFoundExceptionExceptionHandler (ExerciseNotFoundException e){
+    public Response exerciseNotFoundExceptionHandler (ExerciseNotFoundException e){
         return Response.failure(MISSION_NOT_FOUND_EXCEPTION);
     }
 

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -103,6 +103,15 @@ public class ExceptionAdvice {
     }
 
     /*
+    Exercise
+     */
+    @ExceptionHandler(ExerciseNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Response exerciseNotFoundExceptionExceptionHandler (ExerciseNotFoundException e){
+        return Response.failure(MISSION_NOT_FOUND_EXCEPTION);
+    }
+
+    /*
     Query Param
      */
     @ExceptionHandler(WrongRequestParamException.class)

--- a/src/main/java/com/soma/snackexercise/controller/exercise/ExerciseController.java
+++ b/src/main/java/com/soma/snackexercise/controller/exercise/ExerciseController.java
@@ -30,7 +30,6 @@ public class ExerciseController {
                responses = {
                     @ApiResponse(responseCode = "200", description = "운동 생성 성공")
                })
-    @Parameter(name = "request", description = "운동 생성 정보", required = true, in = ParameterIn.DEFAULT)
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Response create(@RequestBody ExerciseCreateRequest request) {

--- a/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
+++ b/src/main/java/com/soma/snackexercise/controller/member/MemberController.java
@@ -34,7 +34,6 @@ public class MemberController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "회원 수정 성공", content = @Content(schema = @Schema(implementation = MemberResponse.class)))
             })
-    @Parameter(name = "memberId", description = "수정할 회원 ID", required = true,  in = ParameterIn.PATH)
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
     public Response update(@RequestBody MemberUpdateRequest request, @AuthenticationPrincipal UserDetails loginUser) {

--- a/src/main/java/com/soma/snackexercise/domain/group/CreateGroupCode.java
+++ b/src/main/java/com/soma/snackexercise/domain/group/CreateGroupCode.java
@@ -5,13 +5,12 @@ import java.util.Random;
 public class CreateGroupCode {
 
     private static Random random = new Random();
+    private static int leftLimit = 48; // numeral '0'
+    private static int rightLimit = 57; // numeral '9'
+    private static int targetStringLength = 6;
 
     public static String createGroupCode(){
-        int leftLimit = 48; // numeral '0'
-        int rightLimit = 122; // letter 'z'
-        int targetStringLength = 6;
         return random.ints(leftLimit, rightLimit + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97)) // 영어 필터링
                 .limit(targetStringLength)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
                 .toString();

--- a/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
+++ b/src/main/java/com/soma/snackexercise/domain/mission/Mission.java
@@ -95,13 +95,14 @@ public class Mission extends BaseTimeEntity {
     }
 
     public Boolean isValidTimeReminder(LocalDateTime now, Integer checkIntervalTime, Integer scheduledFixedRate) {
-        long differenceInSeconds = ChronoUnit.SECONDS.between(now, getCreatedAt());
+        long differenceInMinutes = ChronoUnit.MINUTES.between(now, getCreatedAt()) % checkIntervalTime; // (createdAt - now) % checkIntervalTime
 
-        if(differenceInSeconds < 0) {
+        System.out.println("[시각 차이] : differenceInMinutes = " + differenceInMinutes);
+        if(differenceInMinutes < 0) {
             return false;
         }
 
-        long reminderTime = differenceInSeconds - (checkIntervalTime * 60);
+        long reminderTime = differenceInMinutes - checkIntervalTime;
 
         return reminderTime < scheduledFixedRate;
     }

--- a/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponse.java
@@ -46,8 +46,6 @@ public class GroupResponse {
 
     private String penalty; // 벌칙
 
-    private String code; // 그룹 입장 코드
-
     private Integer checkIntervalTime; // 미션 수행 체크 시간 간격
 
     private Integer checkMaxNum; // 일별 미션 수행 체크 최대 횟수
@@ -67,7 +65,6 @@ public class GroupResponse {
                 group.getStartDate(),
                 group.getEndDate(),
                 group.getPenalty(),
-                group.getCode(),
                 group.getCheckIntervalTime(),
                 group.getCheckMaxNum()
         );

--- a/src/main/java/com/soma/snackexercise/exception/NotStartedGroupException.java
+++ b/src/main/java/com/soma/snackexercise/exception/NotStartedGroupException.java
@@ -1,0 +1,4 @@
+package com.soma.snackexercise.exception;
+
+public class NotStartedGroupException extends RuntimeException{
+}

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -64,6 +64,7 @@ public class GroupService {
                 .goalRelayNum(groupCreateRequest.getGoalRelayNum())
                 .startTime(groupCreateRequest.getStartTime())
                 .endTime(groupCreateRequest.getEndTime())
+                .existDays(groupCreateRequest.getExistDays())
                 .penalty(groupCreateRequest.getPenalty())
                 .code(groupCode)
                 .checkIntervalTime(groupCreateRequest.getCheckIntervalTime())

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -80,12 +80,11 @@ public class MissionService {
         }
 
         // 1. 오늘 날짜의 모든 미션 조회
-        LocalDateTime now = LocalDateTime.now().minusDays(1);// 현재 날짜와 시간 가져오기
+        LocalDateTime now = LocalDateTime.now();// 현재 날짜와 시간 가져오기
         LocalDateTime todayMidnight = now.with(LocalTime.MIN);// 오늘 자정 구하기
         LocalDateTime tomorrowMidnight = now.plusDays(1).with(LocalTime.MIN);// 내일 자정 구하기
 
         List<Mission> missions = missionRepository.findFinishedMissionsByGroupIdWithinDateRange(exgroupId, todayMidnight, tomorrowMidnight);
-
         return calcRankFromMissionList(missions);
     }
 
@@ -96,6 +95,9 @@ public class MissionService {
      */
     public Object readCumulativeMissionRank(Long exgroupId) {
         Group group = groupRepository.findByIdAndStatus(exgroupId, ACTIVE).orElseThrow(GroupNotFoundException::new);
+        if (group.getStartDate() == null){
+            throw new NotStartedGroupException();
+        }
 
         List<Mission> missions = missionRepository.findFinishedMissionsByGroupIdWithinDateRange(exgroupId, group.getStartDate().atStartOfDay(), group.getEndDate().atStartOfDay().plusDays(1));
 


### PR DESCRIPTION
## 작업사항
- API 검토 및 수정

## 변경로직
- 그룹 코드 영어 + 숫자 조합에서 숫자 조합으로 변경
- 에러 핸들러 추가 : 존재하지 않는 운동, 그룹 시작 안했을 경우 에러 핸들러 추가
- 스케줄러 시간 단위 1분으로 조정함에 따라서 로직 수정
- 그룹 시작 시간에 미션 할당 시, 현재 시각을 기준으로 앞 1분, 뒤 1분 모두 미션이 할당되게 되는 문제를 현재 시각이 그룹 시작 시간보다 이후인 경우에만 할당이 되도록 로직 수정
