### PR TITLE
[Fix] 그룹코드 필드 추가

### DIFF
--- a/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponse.java
@@ -44,6 +44,8 @@ public class GroupResponse {
     @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate endDate; // 종료 기간
 
+    private String code;
+
     private String penalty; // 벌칙
 
     private Integer checkIntervalTime; // 미션 수행 체크 시간 간격
@@ -64,6 +66,7 @@ public class GroupResponse {
                 group.getExistDays(),
                 group.getStartDate(),
                 group.getEndDate(),
+                group.getCode(),
                 group.getPenalty(),
                 group.getCheckIntervalTime(),
                 group.getCheckMaxNum()


### PR DESCRIPTION
## 작업사항
- 하나의 그룹 정보 조회 API의 response에 그룹 코드 필드 추가
보안 상의 이유로 클라이언트 측에 그룹코드를 넘기지 않아야겠다고 생각하여 삭제했으나, 클라이언트에서 그룹 초대시 초대 코드를 사용해야함에 따라서 추가하였다.

## 변경로직
- 하나의 그룹 정보 조회 API의 response에 그룹 코드 필드 추가
