### PR TITLE
[Fix] 그룹 시작 시 미션 할당 API 현재 수행 중인 멤버 update 로직 추가

### DIFF
--- a/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
@@ -21,6 +21,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     List<Group> findAllByIsGoalAchievedAndStatus(Boolean isGoalAchieved, Status status);
 
+    List<Group> findAllByCreatedAtNotNullAndIsGoalAchievedAndStatus(Boolean isGoalAchieved, Status status);
+
     /**
      * 상태가 ACTIVE 하면서 인자로 들어온 날짜보다 endAt 필드가 더 오래된 모든 그룹을 반환한다.
      * @param now

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -193,7 +193,7 @@ public class GroupService {
         LocalTime now = LocalTime.now();
         List<Exercise> exerciseList = exerciseRepository.findAll();
 
-        if(now.isAfter(group.getStartTime()) && now.isBefore(group.getEndTime())){
+        if(now.isAfter(group.getStartTime()) && now.isBefore(group.getEndTime()) && group.getCurrentDoingMemberId() == null){ // 그룹 운동 시간 안이고, 그룹에 미션 할당된 사람이 없는 경우
             log.info("============= 그룹 시작, [그룹명] : {} =============", group.getName());
             Member targetMember = missionUtil.getNextMissionMember(group);
             missionUtil.allocateMission(targetMember, group, exerciseList);

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -53,8 +53,8 @@ public class MissionSchedulerService {
     @Transactional
     public void allocateMissionAtGroupStartTime() {
         log.info("============= 그룹 시작 시간 미션 할당 스케줄러 =============");
-        // 종료 여부가 false인 group에 대해서
-        List<Group> groupList = groupRepository.findAllByIsGoalAchievedAndStatus(false, Status.ACTIVE);
+        // 종료 여부가 false이고, 아직 시작하지 않은 그룹에 대해서
+        List<Group> groupList = groupRepository.findAllByCreatedAtNotNullAndIsGoalAchievedAndStatus(false, Status.ACTIVE);
         List<String> tokenList = new ArrayList<>();
         List<Exercise> exerciseList = exerciseRepository.findAll();
 

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionUtil.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionUtil.java
@@ -84,6 +84,7 @@ public class MissionUtil {
                 .member(member)
                 .group(group)
                 .build());
+        group.updateCurrentDoingMemberId(member.getId());
 
         log.info("그룹명 : {}, 그룹원 : {}, 할당 시각 : {}", group.getName(), member.getName(), LocalDateTime.now());
         return  member;


### PR DESCRIPTION
## 작업사항
- 그룹 시작 시 미션 할당 API 현재 수행 중인 멤버 update 로직 추가
- 그룹 시작 시간 미션 할당 스케줄러 수정

## 변경로직
- 그룹 시작 시 미션 할당 API에서, 미션을 할당 해주지만, group 테이블의 currentDoingMemberId 필드는 update가 되지 않는다는 에러를 해결
       - currentDoingMemberId 컬럼은 역정규화 필드로 우리가 직접 신경써서 update를 해줘야한다.
- 그룹 시작 시간에 미션 할당 스케줄러에서, 아직 시작하지 않은 그룹은 제외하도록 수정
