### PR TITLE
[Fix] 스케줄러 비동기 처리, 자동 독촉 스케줄러에서 미션 수행자와 나머지 그룹원 푸시 알림 분리

### DIFF
--- a/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
+++ b/src/main/java/com/soma/snackexercise/SnackExerciseApplication.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import javax.annotation.PostConstruct;
@@ -13,6 +14,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 @Slf4j
+@EnableAsync
 @EnableScheduling
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "https://dev-api.snackexercise.com")})
 @EnableJpaAuditing

--- a/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationMessage {
-    MANUAL_REMINDER("님이 당신의 운동을 기다리고 있어요!", "잠깐의 운동이 당신의 하루에 큰 변화를 가져올 거예요!"),
-    AUTOMATIC_REMINDER("님이 운동을 안하고 있어요!", "님이 지금 당장 운동할 수 있도록 독촉해보세요!"),
+    MANUAL_REMINDER("님이 당신의 운동을 기다리고 있어요!😃", "잠깐의 운동이 당신의 하루에 큰 변화를 가져올 거예요!💙"),
+    AUTOMATIC_REMINDER_FOR_GROUPMEMBER("님이 운동을 안하고 있어요!", "님이 지금 당장 운동할 수 있도록 독촉해보세요!👏🏻"),
+    AUTOMATIC_REMINDER_TARGETMEMBER("비타민 같은 미션 운동이 기다리고 있어요!🍊", "미션을 수행하고 다음 사람에게 미션을 넘겨보아요!😃"),
     ALLOCATE("운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥"),
     GROUP_GOAL_ACHIEVE("그룹 목표 달성! 🙌", "그룹의 목표 릴레이 횟수를 모두 달성했어요! 👍🏻"),
     GROUP_END("그룹이 종료되었어요!", "그룹의 운동 기간이 종료되었어요! 함께한 시간 동안 수고 많으셨습니다! 🙌");

--- a/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
@@ -21,7 +21,7 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     List<Group> findAllByIsGoalAchievedAndStatus(Boolean isGoalAchieved, Status status);
 
-    List<Group> findAllByCreatedAtNotNullAndIsGoalAchievedAndStatus(Boolean isGoalAchieved, Status status);
+    List<Group> findAllByStartDateNotNullAndIsGoalAchievedAndStatus(Boolean isGoalAchieved, Status status);
 
     /**
      * 상태가 ACTIVE 하면서 인자로 들어온 날짜보다 endAt 필드가 더 오래된 모든 그룹을 반환한다.

--- a/src/main/java/com/soma/snackexercise/service/notification/FirebaseCloudMessageService.java
+++ b/src/main/java/com/soma/snackexercise/service/notification/FirebaseCloudMessageService.java
@@ -1,11 +1,17 @@
 package com.soma.snackexercise.service.notification;
 
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,28 +27,28 @@ public class FirebaseCloudMessageService {
     @Value("${fcm.key.scope}")
     private String fireBaseScope;
 
-    // fcm 기본 설정 진행
-//    @PostConstruct
-//    public void init() {
-//        try {
-//            FirebaseOptions options = new FirebaseOptions.Builder()
-//                    .setCredentials(
-//                            GoogleCredentials
-//                                    .fromStream(new ClassPathResource(FCM_PRIVATE_KEY_PATH).getInputStream())
-//                                    .createScoped(List.of(fireBaseScope)))
-//                    .build();
-//
-//            if (FirebaseApp.getApps().isEmpty()) {
-//                FirebaseApp.initializeApp(options);
-//                log.info("Firebase application has been initialized");
-//            }
-//        } catch (IOException e) {
-//            log.error(e.getMessage());
-//            e.printStackTrace();
-//            // spring 뜰때 알림 서버가 잘 동작하지 않는 것이므로 바로 죽임
-//            throw new RuntimeException(e.getMessage());
-//        }
-//    }
+     //fcm 기본 설정 진행
+    @PostConstruct
+    public void init() {
+        try {
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(
+                            GoogleCredentials
+                                    .fromStream(new ClassPathResource(FCM_PRIVATE_KEY_PATH).getInputStream())
+                                    .createScoped(List.of(fireBaseScope)))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase application has been initialized");
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            e.printStackTrace();
+            // spring 뜰때 알림 서버가 잘 동작하지 않는 것이므로 바로 죽임
+            throw new RuntimeException(e.getMessage());
+        }
+    }
 
 
 


### PR DESCRIPTION
## 작업사항
- 스케줄러 비동기 처리
- 자동 독촉 스케줄러에서 미션 수행자와 나머지 그룹원 푸시 알림 분리


## 변경로직
- 스케줄러 비동기 처리
     - 각각의 스케줄러가 개별적으로 동작되어야 하기에 비동기 처리를 수행하는 코드를 추가하였습니다.
     - 각 함수에 @Async, Application Class에는 @EnableAsync 어노테이션을 추가하였습니다.
- 자동 독촉 스케줄러에서 미션 수행자와 나머지 그룹원 푸시 알림 분리
     - 미션 수행자에게는 미션 수행을 독려하는 푸시 메세지 전송
     - 미션 수행자 이외의 그룹원에게는 미션 수행자의 미션 수행을 독촉하라는 푸시 메시지 전송
- 그룹 시작 시간 미션 할당 스케줄러에서 그룹 생성 일자가 아닌, 그룹 시작 일자가 null이 아닌 그룹 가져오기로 repository 수정
    - 그룹이 시작하면 그룹 시작 일자가 null이 아닌 실제 날짜값이 기록됩니다. 따라서, 그룹이 DB에 생성될 때 기록되는 그룹 생성일자가 아닌, 그룹 시작 일자의 null 여부를 체크해야합니다.
