### PR TITLE
[Fix] 로그인, 회원가입시 fcmToken 받도록 수정

### DIFF
--- a/src/main/java/com/soma/snackexercise/dto/auth/MvpLoginRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/auth/MvpLoginRequest.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MvpLoginRequest {
     private String nickname;
+    private String fcmToken;
 }

--- a/src/main/java/com/soma/snackexercise/dto/signup/SignupRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/signup/SignupRequest.java
@@ -10,4 +10,5 @@ public class SignupRequest {
     private String nickname;
     private Gender gender;
     private Integer birthYear;
+    private String fcmToken;
 }

--- a/src/main/java/com/soma/snackexercise/service/auth/MvpAuthService.java
+++ b/src/main/java/com/soma/snackexercise/service/auth/MvpAuthService.java
@@ -7,9 +7,11 @@ import com.soma.snackexercise.dto.auth.MvpLoginResponse;
 import com.soma.snackexercise.exception.member.MemberNicknameAlreadyExistsException;
 import com.soma.snackexercise.exception.member.MemberNotFoundException;
 import com.soma.snackexercise.repository.member.MemberRepository;
+import com.soma.snackexercise.service.notification.NotificationService;
 import com.soma.snackexercise.util.constant.Status;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -18,7 +20,9 @@ import java.util.UUID;
 public class MvpAuthService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+    private final NotificationService notificationService;
 
+    @Transactional
     public MvpLoginResponse signup(MvpLoginRequest request) {
         String email = UUID.randomUUID() + "@socialUser.com";
 
@@ -28,6 +32,8 @@ public class MvpAuthService {
                 .email(email)
                 .nickname(request.getNickname())
                 .build();
+        // fcm 토큰 저장
+        member.updateFcmToken(request.getFcmToken());
 
         memberRepository.save(member);
 
@@ -36,10 +42,14 @@ public class MvpAuthService {
         return new MvpLoginResponse("Bearer " + accessToken, member.getId());
     }
 
+    @Transactional
     public MvpLoginResponse login(MvpLoginRequest request) {
         Member member = memberRepository.findByNicknameAndStatus(request.getNickname(), Status.ACTIVE).orElseThrow(MemberNotFoundException::new);
 
         String accessToken = jwtService.createAccessToken(member.getEmail());
+
+        // fcm 토큰 저장
+        member.updateFcmToken(request.getFcmToken());
 
         return new MvpLoginResponse("Bearer " + accessToken, member.getId());
     }

--- a/src/main/java/com/soma/snackexercise/service/signup/SignupService.java
+++ b/src/main/java/com/soma/snackexercise/service/signup/SignupService.java
@@ -15,12 +15,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 @Service
 public class SignupService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
 
+    @Transactional
     public void signup(SignupRequest signupRequest, HttpServletRequest request, HttpServletResponse response) {
         validateSignup(signupRequest);
         String email = jwtService.extractRefreshToken(request);
@@ -30,6 +31,9 @@ public class SignupService {
         String newRefreshToken = jwtService.createRefreshToken(email);
         jwtService.sendRefreshToken(response, newRefreshToken);
         jwtService.updateRefreshToken(email, newRefreshToken);
+
+        // fcm 토큰 저장
+        findMember.updateFcmToken(signupRequest.getFcmToken());
     }
 
     private void validateSignup(SignupRequest request) {


### PR DESCRIPTION
## 작업사항
- 로그인, 회원가입시 fcmToken 받도록 수정

## 변경로직
- 기존에 FcmToken 저장 API는 추후 OAuth 로그인시 필요하기에 남겨두기로 결정
- mvp 로그인, 회원가입의 request body에 fcmToken 추가로 받도록 설정
