### PR TITLE
[Fix] 당일 미션 랭킹 조회, 그룹코드로 그룹 가입 API 수정 및 종료된 그룹 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/soma/snackexercise/controller/group/GroupController.java
+++ b/src/main/java/com/soma/snackexercise/controller/group/GroupController.java
@@ -118,4 +118,11 @@ public class GroupController {
     public Response readAllJoinGroups(@AuthenticationPrincipal UserDetails loginUser) {
         return Response.success(groupService.readAllJoinGroups(loginUser.getUsername()));
     }
+
+    @Operation(summary = "회원이 가입했던 종료된 그룹 조회하기", description = "회원이 가입했던 종료된 그룹을 조회합니다.", security = { @SecurityRequirement(name = "bearer-key") })
+    @GetMapping("/finish")
+    @ResponseStatus(HttpStatus.OK)
+    public Response readAllFinishedJoinGroups(@AuthenticationPrincipal UserDetails loginUser) {
+        return Response.success(groupService.readAllFinishedJoinGroups(loginUser.getUsername()));
+    }
 }

--- a/src/main/java/com/soma/snackexercise/domain/group/Group.java
+++ b/src/main/java/com/soma/snackexercise/domain/group/Group.java
@@ -96,6 +96,10 @@ public class Group extends BaseEntity {
         return now.isAfter(startTime) && now.isBefore(endTime);
     }
 
+    public Boolean isStarted(){
+        return this.startDate != null;
+    }
+
     @Builder
     public Group(String name, String emozi, String color, String description,
                  Integer maxMemberNum, Integer goalRelayNum, LocalTime startTime,

--- a/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
+++ b/src/main/java/com/soma/snackexercise/domain/joinlist/JoinList.java
@@ -38,6 +38,11 @@ public class JoinList extends BaseEntity {
         this.executedMissionCount += 1;
     }
 
+    public void updateExecutedMissionCount(Integer executedMissionCount) {
+        this.executedMissionCount = executedMissionCount;
+    }
+
+
     public void promoteToHost() {
         this.joinType = JoinType.HOST;
     }

--- a/src/main/java/com/soma/snackexercise/dto/group/response/FinishedGroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/group/response/FinishedGroupResponse.java
@@ -1,0 +1,31 @@
+package com.soma.snackexercise.dto.group.response;
+
+import com.soma.snackexercise.domain.group.Group;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinishedGroupResponse {
+    private Long groupId;
+    private String groupName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer finishedRelayNum; // 그룹이 수행 완료한 횟수
+    private Integer goalRelayNum; // 그룹 목표 릴레이 횟수
+
+    public static FinishedGroupResponse toDto(Group group, Integer finishedRelayNum){
+        return new FinishedGroupResponse(
+                group.getId(),
+                group.getName(),
+                group.getStartDate(),
+                group.getEndDate(),
+                finishedRelayNum,
+                group.getGoalRelayNum()
+        );
+    }
+}

--- a/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
@@ -110,6 +110,14 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long> {
     @Query("SELECT j from JoinList j JOIN FETCH j.group g WHERE j.member = :member AND j.status = 'ACTIVE'")
     List<JoinList> findAllActiveJoinGroupsByMember(@Param("member") Member member);
 
+    /**
+     * 회원이 가입했고, 종료된 그룹과 JoinList를 조회합니다.
+     * @param member 회원
+     * @return 회원이 가입했고, 종료된 JoinList와 Group
+     */
+    @Query("SELECT j from JoinList j JOIN FETCH j.group g WHERE j.member = :member AND j.status = 'INACTIVE'")
+    List<JoinList> findAllInactiveJoinGroupsByMember(@Param("member") Member member);
+
 
     @Query("SELECT CASE WHEN COUNT(DISTINCT j.executedMissionCount) = 1 " +
             "THEN MAX(j.executedMissionCount) + 1 " +

--- a/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
@@ -127,6 +127,12 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long> {
             "AND j.status = :status ")
     Integer findMaxExecutedMissionCountByGroupAndStatus(@Param("group") Group group, @Param("status") Status status);
 
+    @Query("SELECT MIN(j.executedMissionCount)" +
+            "FROM JoinList j " +
+            "WHERE j.group = :group " +
+            "AND j.status = :status ")
+    Integer findMinExecutedMissionCountByGroupAndStatus(@Param("group") Group group, @Param("status") Status status);
+
     @Query("SELECT COUNT(j) " +
             "FROM JoinList j " +
             "WHERE j.group = :group " +

--- a/src/main/java/com/soma/snackexercise/repository/mission/MissionRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/mission/MissionRepository.java
@@ -61,7 +61,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
      */
     @Query("SELECT m" +
             "   FROM Mission m JOIN FETCH m.member" +
-            "   WHERE m.group.id = :groupId AND :startDateTime <= m.createdAt AND m.createdAt < :endDateTime AND m.startAt IS NOT NULL" +
+            "   WHERE m.group.id = :groupId AND :startDateTime <= m.createdAt AND m.createdAt < :endDateTime AND m.endAt IS NOT NULL" +
             "   ORDER BY m.createdAt")
     List<Mission> findFinishedMissionsByGroupIdWithinDateRange(@Param("groupId") Long groupId, @Param("startDateTime") LocalDateTime startDateTime, @Param("endDateTime") LocalDateTime endDateTime);
 

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -226,6 +226,19 @@ public class GroupService {
 
         validateJoinGroup(group, member);
 
+        // 이미 시작한 그룹에 중간에 참여하는 경우, 그룹원 중 가장 적은 수행횟수만큼 수행했다고 간주한다.
+        if(group.isStarted()){
+            JoinList joinList = JoinList.builder()
+                    .member(member)
+                    .group(group)
+                    .joinType(JoinType.MEMBER)
+                    .build();
+
+            joinList.updateExecutedMissionCount(joinListRepository.findMinExecutedMissionCountByGroupAndStatus(group, ACTIVE));
+            joinListRepository.save(joinList);
+            return;
+        }
+
         joinListRepository.save(
                 JoinList.builder()
                 .member(member)

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -9,6 +9,7 @@ import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.dto.group.request.GroupCreateRequest;
 import com.soma.snackexercise.dto.group.request.GroupUpdateRequest;
 import com.soma.snackexercise.dto.group.request.JoinFriendGroupRequest;
+import com.soma.snackexercise.dto.group.response.FinishedGroupResponse;
 import com.soma.snackexercise.dto.group.response.GroupCreateResponse;
 import com.soma.snackexercise.dto.group.response.GroupResponse;
 import com.soma.snackexercise.dto.group.response.JoinGroupResponse;
@@ -23,6 +24,7 @@ import com.soma.snackexercise.repository.joinlist.JoinListRepository;
 import com.soma.snackexercise.repository.member.MemberRepository;
 import com.soma.snackexercise.service.mission.MissionUtil;
 import com.soma.snackexercise.service.notification.FirebaseCloudMessageService;
+import com.soma.snackexercise.util.constant.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -207,8 +209,9 @@ public class GroupService {
         }
 
         // 4. 그룹원 모두에게 그룹 시작 푸시알림 전송
-        List<String> tokenList = joinListRepository.findByGroupAndStatus(group, ACTIVE).stream().map(joinList -> joinList.getMember().getFcmToken()).toList();
+        List<String> tokenList = joinListRepository.findByGroupAndStatus(group, ACTIVE).stream().filter(joinList -> joinList.getMember().getFcmToken() != null).map(joinList -> joinList.getMember().getFcmToken()).toList();
         if (!tokenList.isEmpty()) {
+            System.out.println("tokenList = " + tokenList);
             // tokenList로 알림 보내기
             firebaseCloudMessageService.sendByTokenList(tokenList, ALLOCATE.getTitle(), ALLOCATE.getBody());
         }
@@ -252,5 +255,16 @@ public class GroupService {
 
         // 그룹 ID, 그룹 명, 현재 미션 진행중인 회원의 ID 추출
         return joinLists.stream().map(joinList -> JoinGroupResponse.toDto(joinList.getGroup())).toList();
+    }
+
+    public List<FinishedGroupResponse> readAllFinishedJoinGroups(String email) {
+        Member member = memberRepository.findByEmailAndStatus(email, ACTIVE).orElseThrow(MemberNotFoundException::new);
+
+        // 회원이 가입했지만 종료한 모든 그룹
+        List<JoinList> joinLists = joinListRepository.findAllInactiveJoinGroupsByMember(member);
+        return joinLists.stream().map(joinList -> FinishedGroupResponse.toDto(
+                joinList.getGroup(),
+                joinListRepository.findMaxExecutedMissionCountByGroupAndStatus(joinList.getGroup(), INACTIVE))).toList();// 그룹이 현재 완료한 릴레이 횟수
+
     }
 }


### PR DESCRIPTION
## 작업사항
- 당일 미션 랭킹 조회 API 수정
- 종료된 그룹 정보 조회하기 API 구현
- 그룹 코드로 그룹 가입 API에서 이미 시작한 그룹에 중간에 참여하는 참여자에 대한 로직 추가

## 변경로직
- 당일 미션 랭킹 조회 API 수정
     - 미션을 시작하고, 수행하는 중인데도 불구하고 상대방의 화면에서는 미션 랭킹에 보여지는 에러 처리
     - 종료된 미션에 대해서만 랭킹에서 보여지도록 로직 수정
- 종료된 그룹 정보 조회하기 API 구현
- 그룹 코드로 그룹 가입 API에서 이미 시작한 그룹에 중간에 참여하는 참여자에 대한 로직 추가
    - 가장 적은 미션 수행횟수를 가진 사람들 중에서 랜덤하게 미션이 부여되기에, 중간 참여자의 경우, 그룹원들 중 가장 적은 수행횟수만큼 수행했다고 간주하는 로직을 추가해야한다.
