### PR TITLE
[Fix] 종료된 그룹 정보 조회 response 그룹 목표 성공 여부 필드 추가

### DIFF
--- a/src/main/java/com/soma/snackexercise/dto/group/response/FinishedGroupResponse.java
+++ b/src/main/java/com/soma/snackexercise/dto/group/response/FinishedGroupResponse.java
@@ -17,6 +17,7 @@ public class FinishedGroupResponse {
     private LocalDate endDate;
     private Integer finishedRelayNum; // 그룹이 수행 완료한 횟수
     private Integer goalRelayNum; // 그룹 목표 릴레이 횟수
+    private Boolean isGoalAchieved; // 그룹 릴레이 성공 여부
 
     public static FinishedGroupResponse toDto(Group group, Integer finishedRelayNum){
         return new FinishedGroupResponse(
@@ -25,7 +26,8 @@ public class FinishedGroupResponse {
                 group.getStartDate(),
                 group.getEndDate(),
                 finishedRelayNum,
-                group.getGoalRelayNum()
+                group.getGoalRelayNum(),
+                group.getIsGoalAchieved()
         );
     }
 }

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -196,7 +196,7 @@ public class MissionService {
         Group group = mission.getGroup();
         JoinList joinList = joinListRepository.findByGroupAndMemberAndStatus(group, member, ACTIVE).orElseThrow(JoinListNotFoundException::new);
         joinList.addOneExecutedMissionCount();
-        log.info("[미션 수행 완료] 그룹명 : {}", group.getName());
+        log.info("[미션 수행 완료] 그룹명 : {}, 회원명 : {}", group.getName(), member.getNickname());
 
         // 3. 모든 그룹원이 목표한 릴레이횟수만큼 수행 시, 그룹 목표 달성 및 푸시 알림 보내기
         if(joinListRepository.countGroupGoalAchievedMember(group) == joinListRepository.countGroupMember(group)){
@@ -205,7 +205,7 @@ public class MissionService {
             // 멤버 전원에게 미션 성공 푸시 알림 전송
             List<String> tokenList = joinListRepository.findByGroupAndStatus(group, ACTIVE).stream().map(joinList1 -> joinList1.getMember().getFcmToken()).toList();
             firebaseCloudMessageService.sendByTokenList(tokenList, GROUP_GOAL_ACHIEVE.getTitle(), GROUP_GOAL_ACHIEVE.getBody());
-            log.info("[그룹 목표 달성] 그룹명 : {}", group.getName());
+            log.info("[그룹 목표 달성] 그룹명 : {}, 회원명 : {}", group.getName(), member.getNickname());
 
             return new MissionFinishResponse(group.getIsGoalAchieved());
         }


### PR DESCRIPTION
## 작업사항
- 종료된 그룹 정보 조회 API response 수정
- 미션 수행 완료 API 로그 회원명 추가

## 변경로직
- 종료된 그룹 정보 조회 response 그룹 목표 성공 여부 필드 추가
- 미션 수행완료 API에서 미션 수행 완료시 회원명 로그 출력
