### PR TITLE
[Fix] 그룹 목표 성공시 즉시 그룹, JoinList INACTIVE 처리

### DIFF
--- a/src/main/java/com/soma/snackexercise/domain/group/Group.java
+++ b/src/main/java/com/soma/snackexercise/domain/group/Group.java
@@ -89,7 +89,8 @@ public class Group extends BaseEntity {
 
     public void updateIsGoalAchieved(){
         this.isGoalAchieved = TRUE;
-
+        this.currentDoingMemberId = null;
+        inActive(); // TODO : 그룹 미션 성공시 바로 Inactive 처리하도록 수정 (08/08)
     }
 
     public Boolean isCurrentTimeBetweenStartTimeAndEndTime(LocalTime now) {

--- a/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponseIncludeHost.java
+++ b/src/main/java/com/soma/snackexercise/dto/group/response/GroupResponseIncludeHost.java
@@ -1,0 +1,78 @@
+package com.soma.snackexercise.dto.group.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import com.soma.snackexercise.domain.group.Group;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupResponseIncludeHost {
+    private Long groupId;
+
+    private String groupName; // 그룹 이름
+
+    private String emozi; // 그룹 대표 이모지
+
+    private String color; // 그룹 대표 색상
+
+    private String description; // 그룹 소개 글
+
+    private Integer maxMemberNum; // 최대 참여 인원 수
+
+    private Integer goalRelayNum; // 목표 릴레이 횟수
+
+    @JsonSerialize(using = LocalTimeSerializer.class) // 객체 -> JSON
+    private LocalTime startTime; // 시작 시간
+
+    @JsonSerialize(using = LocalTimeSerializer.class)
+    private LocalTime endTime; // 종료 시간
+
+    private Integer existDays; // 그룹 목표 일수
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    private LocalDate startDate; // 시작 기간
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    private LocalDate endDate; // 종료 기간
+
+    private String code;
+
+    private String penalty; // 벌칙
+
+    private Integer checkIntervalTime; // 미션 수행 체크 시간 간격
+
+    private Integer checkMaxNum; // 일별 미션 수행 체크 최대 횟수
+
+    private Long hostMemberId; // 방장 ID
+
+    public static GroupResponseIncludeHost toDto(Group group, Long hostMemberId) {
+        return new GroupResponseIncludeHost(
+                group.getId(),
+                group.getName(),
+                group.getEmozi(),
+                group.getColor(),
+                group.getDescription(),
+                group.getMaxMemberNum(),
+                group.getGoalRelayNum(),
+                group.getStartTime(),
+                group.getEndTime(),
+                group.getExistDays(),
+                group.getStartDate(),
+                group.getEndDate(),
+                group.getCode(),
+                group.getPenalty(),
+                group.getCheckIntervalTime(),
+                group.getCheckMaxNum(),
+                hostMemberId
+        );
+    }
+}

--- a/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/joinlist/JoinListRepository.java
@@ -155,4 +155,9 @@ public interface JoinListRepository extends JpaRepository<JoinList, Long> {
      */
     @Query("SELECT count(*) FROM JoinList j WHERE j.group = :group AND j.status = 'ACTIVE'")
     Integer countGroupMember(@Param("group") Group group);
+
+    @Query("SELECT j " +
+            "FROM JoinList j JOIN FETCH j.group g " +
+            "WHERE g.id = :groupId AND g.status = :status AND j.joinType = 'HOST'")
+    Optional<JoinList> findHostJoinListByGroupIdAndStatus(@Param("groupId") Long groupId, @Param("status") Status status);
 }

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -9,10 +9,7 @@ import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.dto.group.request.GroupCreateRequest;
 import com.soma.snackexercise.dto.group.request.GroupUpdateRequest;
 import com.soma.snackexercise.dto.group.request.JoinFriendGroupRequest;
-import com.soma.snackexercise.dto.group.response.FinishedGroupResponse;
-import com.soma.snackexercise.dto.group.response.GroupCreateResponse;
-import com.soma.snackexercise.dto.group.response.GroupResponse;
-import com.soma.snackexercise.dto.group.response.JoinGroupResponse;
+import com.soma.snackexercise.dto.group.response.*;
 import com.soma.snackexercise.dto.member.JoinListMemberDto;
 import com.soma.snackexercise.dto.member.response.GetOneGroupMemberResponse;
 import com.soma.snackexercise.exception.group.*;
@@ -98,10 +95,10 @@ public class GroupService {
         return GroupCreateResponse.toDto(newGroup);
     }
 
-    public GroupResponse read(Long groupId){
-        Group group = groupRepository.findByIdAndStatus(groupId, ACTIVE).orElseThrow(GroupNotFoundException::new);
+    public GroupResponseIncludeHost read(Long groupId){
+        JoinList joinList = joinListRepository.findHostJoinListByGroupIdAndStatus(groupId, ACTIVE).orElseThrow(GroupNotFoundException::new);
 
-        return GroupResponse.toDto(group);
+        return GroupResponseIncludeHost.toDto(joinList.getGroup(), joinList.getMember().getId());
     }
 
     public List<GetOneGroupMemberResponse> getAllExgroupMembers(Long groupId){

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -200,7 +200,7 @@ public class MissionService {
 
         // 3. 모든 그룹원이 목표한 릴레이횟수만큼 수행 시, 그룹 목표 달성 및 푸시 알림 보내기
         if(joinListRepository.countGroupGoalAchievedMember(group) == joinListRepository.countGroupMember(group)){
-            group.updateIsGoalAchieved(); // 그룹 목표 달성 여부 update
+            group.updateIsGoalAchieved(); // 그룹 목표 달성 여부 update 및 inactive 처리
 
             // 멤버 전원에게 미션 성공 푸시 알림 전송
             List<String> tokenList = joinListRepository.findByGroupAndStatus(group, ACTIVE).stream().map(joinList1 -> joinList1.getMember().getFcmToken()).toList();

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -200,10 +200,14 @@ public class MissionService {
 
         // 3. 모든 그룹원이 목표한 릴레이횟수만큼 수행 시, 그룹 목표 달성 및 푸시 알림 보내기
         if(joinListRepository.countGroupGoalAchievedMember(group) == joinListRepository.countGroupMember(group)){
-            group.updateIsGoalAchieved(); // 그룹 목표 달성 여부 update 및 inactive 처리
+            group.updateIsGoalAchieved(); // 그룹 목표 달성 여부 update 및 INACTIVE 처리
+
+            // joinList INACTIVE 처리
+            List<JoinList> joinLists = joinListRepository.findByGroupAndStatus(group, ACTIVE);
+            joinLists.forEach(joinListElem -> joinListElem.inActive());
 
             // 멤버 전원에게 미션 성공 푸시 알림 전송
-            List<String> tokenList = joinListRepository.findByGroupAndStatus(group, ACTIVE).stream().map(joinList1 -> joinList1.getMember().getFcmToken()).toList();
+            List<String> tokenList = joinLists.stream().map(joinList1 -> joinList1.getMember().getFcmToken()).toList();
             firebaseCloudMessageService.sendByTokenList(tokenList, GROUP_GOAL_ACHIEVE.getTitle(), GROUP_GOAL_ACHIEVE.getBody());
             log.info("[그룹 목표 달성] 그룹명 : {}, 회원명 : {}", group.getName(), member.getNickname());
 


### PR DESCRIPTION
## 작업사항
- 그룹 목표 성공시 즉시 그룹, JoinList INACTIVE 처리
- 그룹 1개 정보 조회시 HOST 회원 ID도 전달하도록 수정

## 변경로직
- 내용을 적어주세요.
