### PR TITLE
[Fix] FCM 토큰 빈 값, null validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     // mariadb
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     // mysql
-    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+    implementation 'mysql:mysql-connector-java:8.0.32'
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // security test
@@ -61,6 +61,8 @@ dependencies {
     implementation 'io.sentry:sentry-logback:6.25.2'
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.soma.snackexercise.advice;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -38,10 +39,19 @@ public enum ErrorCode {
     WRONG_QUERY_PARAM_EXCEPTION(-1900, "잘못된 Query Param입니다."),
 
     /* FCM */
-    FCM_TOKEN_NOT_FOUND_EXCEPTION(-2000, "FCM 토큰이 없는 회원입니다.");
+    FCM_TOKEN_NOT_FOUND_EXCEPTION(-2000, "FCM 토큰이 없는 회원입니다."),
+
+    /* Validation */
+    NOT_VALID(-2100, "validation 에러입니다.");
+
     ErrorCode(int code, String message){
         this.code = code;
         this.message = message;
+    }
+
+    public ErrorCode changeMessage(String message){
+        this.message = message;
+        return this;
     }
 
     private int code;

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -14,6 +14,7 @@ import com.soma.snackexercise.util.response.Response;
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -157,12 +158,26 @@ public class ExceptionAdvice {
         return Response.failure(WRONG_QUERY_PARAM_EXCEPTION);
     }
 
+    /*
+    FCM Token
+     */
     @ExceptionHandler(FcmTokenEmptyException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Response fcmTokenEmptyExceptionHandler(FcmTokenEmptyException e){
         Sentry.captureException(e);
         return Response.failure(FCM_TOKEN_NOT_FOUND_EXCEPTION);
     }
+
+    /*
+    FCM Token
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response fcmTokenEmptyExceptionHandler(MethodArgumentNotValidException e){
+        Sentry.captureException(e);
+        return Response.failure(NOT_VALID.changeMessage(e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
 
 
 }

--- a/src/main/java/com/soma/snackexercise/controller/auth/MvpAuthController.java
+++ b/src/main/java/com/soma/snackexercise/controller/auth/MvpAuthController.java
@@ -4,7 +4,9 @@ package com.soma.snackexercise.controller.auth;
 import com.soma.snackexercise.dto.auth.MvpLoginRequest;
 import com.soma.snackexercise.service.auth.MvpAuthService;
 import com.soma.snackexercise.util.response.Response;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,13 +17,13 @@ public class MvpAuthController {
     private final MvpAuthService mvpAuthService;
     @PostMapping("/sign-up")
     @ResponseStatus(HttpStatus.OK)
-    public Response signup(@RequestBody  MvpLoginRequest request) {
+    public Response signup(@RequestBody @Valid MvpLoginRequest request) {
         return Response.success(mvpAuthService.signup(request));
     }
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)
-    public Response login(@RequestBody  MvpLoginRequest request) {
+    public Response login(@RequestBody @Valid MvpLoginRequest request) {
         return Response.success(mvpAuthService.login(request));
     }
 }

--- a/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationMessage {
     MANUAL_REMINDER("님이 당신의 운동을 기다리고 있어요!😃", "잠깐의 운동이 당신의 하루에 큰 변화를 가져올 거예요!💙"),
     AUTOMATIC_REMINDER_FOR_GROUPMEMBER("님이 운동을 안하고 있어요!", "님이 지금 당장 운동할 수 있도록 독촉해보세요!👏🏻"),
-    AUTOMATIC_REMINDER_TARGETMEMBER("비타민 같은 미션 운동이 기다리고 있어요!🍊", "미션을 수행하고 다음 사람에게 미션을 넘겨보아요!😃"),
-    ALLOCATE("운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥"),
-    GROUP_GOAL_ACHIEVE("그룹 목표 달성! 🙌", "그룹의 목표 릴레이 횟수를 모두 달성했어요! 👍🏻"),
+    AUTOMATIC_REMINDER_TARGETMEMBER("그룹의 비타민 같은 미션 운동이 기다리고 있어요!🍊", "미션을 수행하고 다음 사람에게 미션을 넘겨보아요!😃"),
+    ALLOCATE("그룹의 운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥"),
+    GROUP_GOAL_ACHIEVE("그룹의 목표 달성! 🙌", "그룹의 목표 릴레이 횟수를 모두 달성했어요! 👍🏻"),
     GROUP_START("그룹이 시작되었습니다!🔥", "그룹의 목표 기간 내 목표 릴레이 횟수를 달성하기 위해 달려보아요!👏🏻"),
     GROUP_END("그룹이 종료되었어요!", "그룹의 운동 기간이 종료되었어요! 함께한 시간 동안 수고 많으셨습니다! 🙌");
 

--- a/src/main/java/com/soma/snackexercise/dto/auth/MvpLoginRequest.java
+++ b/src/main/java/com/soma/snackexercise/dto/auth/MvpLoginRequest.java
@@ -1,5 +1,7 @@
 package com.soma.snackexercise.dto.auth;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MvpLoginRequest {
     private String nickname;
+
+    @NotBlank(message = "fcm 토큰은 필수 값입니다.")
     private String fcmToken;
 }

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -209,7 +209,7 @@ public class GroupService {
         if (!tokenList.isEmpty()) {
             System.out.println("tokenList = " + tokenList);
             // tokenList로 알림 보내기
-            firebaseCloudMessageService.sendByTokenList(tokenList, GROUP_START.getTitle(), GROUP_START.getBody());
+            firebaseCloudMessageService.sendByTokenList(tokenList, GROUP_START.getTitleWithGroupName(group.getName()), GROUP_START.getBody());
         }
 
         return GroupResponse.toDto(group);

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -87,12 +87,14 @@ public class MissionSchedulerService {
                     .build());
 
             log.info("그룹명 : {}, 그룹원 : {}, 할당 시각 : {}", group.getName(), targetMember.getNickname(), LocalDateTime.now());
+
+            if (!tokenList.isEmpty()) {
+                // tokenList로 알림 보내기
+                firebaseCloudMessageService.sendByTokenList(tokenList, ALLOCATE.getTitleWithGroupName(group.getName()), ALLOCATE.getBody());
+            }
         }
 
-        if (!tokenList.isEmpty()) {
-            // tokenList로 알림 보내기
-            firebaseCloudMessageService.sendByTokenList(tokenList, ALLOCATE.getTitle(), ALLOCATE.getBody());
-        }
+
     }
 
     /**
@@ -139,7 +141,7 @@ public class MissionSchedulerService {
             // 미션 수행자 푸시 알림 전송
             String targetMemberFcmToken = targetMember.getFcmToken();
             if (targetMemberFcmToken != null && !targetMemberFcmToken.isEmpty()){
-                firebaseCloudMessageService.sendByToken(targetMemberFcmToken, AUTOMATIC_REMINDER_TARGETMEMBER.getTitle(), AUTOMATIC_REMINDER_TARGETMEMBER.getBody());
+                firebaseCloudMessageService.sendByToken(targetMemberFcmToken, AUTOMATIC_REMINDER_TARGETMEMBER.getTitleWithGroupName(group.getName()), AUTOMATIC_REMINDER_TARGETMEMBER.getBody());
             }
 
             // 미션 수행자 제외한 그룹원에게 푸시 알림 전송

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionService.java
@@ -215,7 +215,7 @@ public class MissionService {
 
             // 멤버 전원에게 미션 성공 푸시 알림 전송
             List<String> tokenList = joinLists.stream().map(joinList1 -> joinList1.getMember().getFcmToken()).toList();
-            firebaseCloudMessageService.sendByTokenList(tokenList, GROUP_GOAL_ACHIEVE.getTitle(), GROUP_GOAL_ACHIEVE.getBody());
+            firebaseCloudMessageService.sendByTokenList(tokenList,  GROUP_GOAL_ACHIEVE.getTitleWithGroupName(group.getName()), GROUP_GOAL_ACHIEVE.getBody());
             log.info("[그룹 목표 달성] 그룹명 : {}, 회원명 : {}", group.getName(), member.getNickname());
 
             return new MissionFinishResponse(group.getIsGoalAchieved());
@@ -242,7 +242,7 @@ public class MissionService {
 //            throw new FcmTokenEmptyException();
 //        }
         if(nextMissionMember.getFcmToken() != null){
-            firebaseCloudMessageService.sendByToken(nextMissionMember.getFcmToken(), ALLOCATE.getTitle(), ALLOCATE.getBody());
+            firebaseCloudMessageService.sendByToken(nextMissionMember.getFcmToken(), ALLOCATE.getTitleWithGroupName(group.getName()), ALLOCATE.getBody());
         }
         log.info("[다음 미션] 그룹원 : {}, 할당 시각 : {}", nextMissionMember.getName(), LocalDateTime.now());
         return new MissionFinishResponse(group.getIsGoalAchieved());


### PR DESCRIPTION
## 작업사항
- fcm 토큰이 빈값이어서 500에러 발생을 방지하기 위해서, 로그인 및 회원가입시 NULL, "", " "을 허용하지 않는 NOT BLANK validation을 추가하였습니다. 
- 푸시 알림 메세지에 그룹의 이름을 추가하였습니다.

## 변경로직
- 내용을 적어주세요.
