### PR TITLE
[Fix] 그룹 시작후 바로 미션 할당 푸시 알림 전송 로직 추가

### DIFF
--- a/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/soma/snackexercise/domain/notification/NotificationMessage.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationMessage {
     MANUAL_REMINDER("님이 당신의 운동을 기다리고 있어요!😃", "잠깐의 운동이 당신의 하루에 큰 변화를 가져올 거예요!💙"),
-    AUTOMATIC_REMINDER_FOR_GROUPMEMBER("님이 운동을 안하고 있어요!", "님이 지금 당장 운동할 수 있도록 독촉해보세요!👏🏻"),
+    AUTOMATIC_REMINDER_FOR_GROUPMEMBER("운동을 안하고 있어요!", "님이 지금 당장 운동할 수 있도록 독촉해보세요!👏🏻"),
     AUTOMATIC_REMINDER_TARGETMEMBER("그룹의 비타민 같은 미션 운동이 기다리고 있어요!🍊", "미션을 수행하고 다음 사람에게 미션을 넘겨보아요!😃"),
     ALLOCATE("그룹의 운동 미션 할당! 💪", "지금 당장 운동 미션을 확인하고 운동을 수행해보세요! 🔥"),
     GROUP_GOAL_ACHIEVE("그룹의 목표 달성! 🙌", "그룹의 목표 릴레이 횟수를 모두 달성했어요! 👍🏻"),
@@ -27,5 +27,9 @@ public enum NotificationMessage {
 
     public String getTitleWithGroupName(String name) {
         return name + title;
+    }
+
+    public String getTitleWithGroupNameAndNickname(String groupName, String nickName) {
+        return groupName + "그룹의 " + nickName + "님이" + title;
     }
 }

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalTime;
 import java.util.List;
 
+import static com.soma.snackexercise.domain.notification.NotificationMessage.ALLOCATE;
 import static com.soma.snackexercise.domain.notification.NotificationMessage.GROUP_START;
 import static com.soma.snackexercise.util.constant.Status.ACTIVE;
 import static com.soma.snackexercise.util.constant.Status.INACTIVE;
@@ -202,6 +203,7 @@ public class GroupService {
             log.info("============= 그룹 시작, [그룹명] : {} =============", group.getName());
             Member targetMember = missionUtil.getNextMissionMember(group);
             missionUtil.allocateMission(targetMember, group, exerciseList);
+            firebaseCloudMessageService.sendByToken(targetMember.getFcmToken(), ALLOCATE.getTitleWithGroupName(group.getName()), ALLOCATE.getBody());
         }
 
         // 4. 그룹원 모두에게 그룹 시작 푸시알림 전송

--- a/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
+++ b/src/main/java/com/soma/snackexercise/service/mission/MissionSchedulerService.java
@@ -153,7 +153,7 @@ public class MissionSchedulerService {
             }
             //joinLists.forEach(joinList -> tokenList.add(joinList.getMember().getFcmToken()));
             if(!tokenList.isEmpty()){
-                firebaseCloudMessageService.sendByTokenList(tokenList, AUTOMATIC_REMINDER_FOR_GROUPMEMBER.getTitleWithNickname(targetMember.getNickname()), AUTOMATIC_REMINDER_FOR_GROUPMEMBER.getBodyWithNickname(targetMember.getNickname()));
+                firebaseCloudMessageService.sendByTokenList(tokenList, AUTOMATIC_REMINDER_FOR_GROUPMEMBER.getTitleWithGroupNameAndNickname(group.getName(), targetMember.getNickname()), AUTOMATIC_REMINDER_FOR_GROUPMEMBER.getBodyWithNickname(targetMember.getNickname()));
             }
 
         }


### PR DESCRIPTION
## 작업사항
- 자동 독촉 푸시 알림 전송시 그룹명과 현재 미션 중인 회원명 나오도록 수정
- 그룹 시작후 바로 미션 할당 푸시 알림 전송 로직 추가

## 변경로직
- 내용을 적어주세요.
