### PR TITLE
[Fix] 현재 본인이 방장이면서 진행중인 그룹명과 중복인 그룹 생성 불가능 로직 추가 

### DIFF
--- a/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
+++ b/src/main/java/com/soma/snackexercise/advice/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     EXCEEDS_KICK_OUT_LIMIT_EXCEPTION(-1205, "그룹에 다시 가입할 수 없습니다."),
     NOT_STARTED_GROUP_EXCEPTION(-1206, "그룹이 아직 시작하지 않았습니다."),
     INVALID_GROUP_TIME_EXCEPTION(-1207, "그룹 운영시간이 아닙니다."),
+    DUPLICATE_GROUP_EXCEPTION(-1208, "중복된 그룹명입니다."),
 
     /* JoinList */
     JOIN_LIST_NOT_FOUND_EXCEPTION(-1300, "회원_운동그룹이 존재하지 않습니다."),

--- a/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
+++ b/src/main/java/com/soma/snackexercise/advice/ExceptionAdvice.java
@@ -110,6 +110,13 @@ public class ExceptionAdvice {
         Sentry.captureException(e);
         return Response.failure(INVALID_GROUP_TIME_EXCEPTION);
     }
+    @ExceptionHandler(DuplicateGroupNameException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response duplicateGroupNameExceptionHandler (DuplicateGroupNameException e){
+        Sentry.captureException(e);
+        return Response.failure(DUPLICATE_GROUP_EXCEPTION);
+    }
+
 
     /*
     JoinList

--- a/src/main/java/com/soma/snackexercise/exception/group/DuplicateGroupNameException.java
+++ b/src/main/java/com/soma/snackexercise/exception/group/DuplicateGroupNameException.java
@@ -1,0 +1,4 @@
+package com.soma.snackexercise.exception.group;
+
+public class DuplicateGroupNameException extends RuntimeException{
+}

--- a/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
+++ b/src/main/java/com/soma/snackexercise/repository/group/GroupRepository.java
@@ -1,8 +1,11 @@
 package com.soma.snackexercise.repository.group;
 
 import com.soma.snackexercise.domain.group.Group;
+import com.soma.snackexercise.domain.member.Member;
 import com.soma.snackexercise.util.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +13,14 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Boolean existsByCodeAndStatus(String code, Status status);
+
+    @Query("SELECT CASE COUNT(*)" +
+            "   WHEN 1 THEN TRUE" +
+            "   ELSE FALSE" +
+            "   END" +
+            "   FROM Group g JOIN JoinList j ON g.id = j.group.id" +
+            "   WHERE j.joinType = 'HOST' AND j.member = :member AND g.name = :groupName AND g.status = :status")
+    Boolean existsByHostMemberAndGroupNameAndStaus(@Param("member") Member member, @Param("groupName") String groupName, @Param("status") Status status);
 
     Boolean existsByIdAndStatus(Long id, Status status);
 

--- a/src/main/java/com/soma/snackexercise/service/group/GroupService.java
+++ b/src/main/java/com/soma/snackexercise/service/group/GroupService.java
@@ -49,9 +49,15 @@ public class GroupService {
 
     @Transactional
     public GroupCreateResponse create(GroupCreateRequest groupCreateRequest, String email){
-
         // 1. 그룹 생성할 회원 조회
         Member member = memberRepository.findByEmailAndStatus(email, ACTIVE).orElseThrow(MemberNotFoundException::new);
+
+        // 방장은 같은 이름의 그룹은 하나만 생성 가능
+        System.out.println("groupRepository.existsByHostMemberAndGroupNameAndStaus(member, groupCreateRequest.getName(), ACTIVE) = " + groupRepository.existsByHostMemberAndGroupNameAndStaus(member, groupCreateRequest.getName(), ACTIVE));
+        if(groupRepository.existsByHostMemberAndGroupNameAndStaus(member, groupCreateRequest.getName(), ACTIVE)){
+            throw new DuplicateGroupNameException();
+        }
+
 
         // 2. 그룹 코드 생성
         String groupCode = CreateGroupCode.createGroupCode();


### PR DESCRIPTION
## 관련 이슈 번호
- close #182

## 작업사항
- 방장이면서 현재 진행중인 그룹들의 이름과 새로 가입하려는 그룹명이 같은 것이 하나 이상 존재하는지 여부 판단하는 repository 함수 생성
- 방장이면서 현재 진행중인 그룹들의 이름과 새로 가입하려는 그룹명이 같은 것이 하나 이상 존재하면 DUPLICATE_GROUP_EXCEPTION을 반환하는 service 함수의 로직 처리

## 변경로직
- 내용을 적어주세요.
